### PR TITLE
Context: Test if file name is actually present

### DIFF
--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -40,8 +40,10 @@ function getCallingFrame(logtail: Node): StackFrame | null {
   return null;
 }
 
-function relativeToMainModule(fileName: string): string {
-  if (fileName.startsWith("file:/")) {
+function relativeToMainModule(fileName: string): string | null {
+  if (typeof(fileName) !== "string") {
+    return null;
+  } else if (fileName.startsWith("file:/")) {
     const url = new URL(fileName);
     return url.pathname;
   } else {


### PR DESCRIPTION
I ran into this bug when I was trying out Next.js serverless functions.