### PR TITLE
Do not throw when logging fails (by default)

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -26,7 +26,7 @@ const defaultOptions: ILogtailOptions = {
   syncMax: 5,
 
   // If true, errors/failed logs should be ignored
-  ignoreExceptions: false
+  ignoreExceptions: true
 };
 
 /**
@@ -196,6 +196,8 @@ class Logtail {
       // Catch any errors - re-throw if `ignoreExceptions` == false
       if (!this._options.ignoreExceptions) {
         throw e;
+      } else {
+        console.error(e);
       }
     }
 


### PR DESCRIPTION
When logging fails, we throw an error, and that can break the rest of the app. I think this should be the default behavior and not the current behavior but I'm open to discussion.