### PR TITLE
Allow filtering logs in a Logtail middleware

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -183,7 +183,10 @@ class Logtail {
     let transformedLog = log as ILogtailLog | null;
     for (const middleware of this._middleware) {
       let newTransformedLog = await middleware(transformedLog as ILogtailLog);
-      if (newTransformedLog == null) return transformedLog as ILogtailLog & TContext;
+      if (newTransformedLog == null) {
+        // Don't push the log if it was filtered out in a middleware
+        return transformedLog as ILogtailLog & TContext;
+      }
       transformedLog = newTransformedLog;
     }
 

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -180,11 +180,12 @@ class Logtail {
       };
     }
 
-    // Pass the log through the middleware pipeline
-    const transformedLog = await this._middleware.reduceRight(
-      (fn, pipedLog) => fn.then(pipedLog),
-      Promise.resolve(log as ILogtailLog)
-    );
+    let transformedLog = log as ILogtailLog | null;
+    for (const middleware of this._middleware) {
+      let newTransformedLog = await middleware(transformedLog as ILogtailLog);
+      if (newTransformedLog == null) return transformedLog as ILogtailLog & TContext;
+      transformedLog = newTransformedLog;
+    }
 
     try {
       // Push the log through the batcher, and sync


### PR DESCRIPTION
Example, allow only `warn` and `error` logs to logtail while allowing them in other winston transports:

```js
const { Logtail } = require("@logtail/node");
const { LogtailTransport } = require("@logtail/winston");

const winston = require("winston");

// Create a logger from a Logtail class
const logtail = new Logtail(process.argv[2]);

logtail.use((log) => { return ['error', 'warn'].includes(log.level) ? log : null });

const logger = winston.createLogger({
    transports: [new LogtailTransport(logtail), ... other transports ...],
});
```

Fixes #9