### PR TITLE
Quick-fix for supporting Deno

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,6 +1,8 @@
 import { Duplex, Writable } from "stream";
 
-import fetch from "cross-fetch";
+import crossFetch from "cross-fetch";
+const fetch = globalThis.fetch || crossFetch;
+
 import { encode } from "@msgpack/msgpack";
 
 import { ILogtailLog, Context, StackContextHint, ILogtailOptions, LogLevel } from "@logtail/types";


### PR DESCRIPTION
Since there's no official support for Deno yet, I tried using this package with Deno instead:

```js
import { Logtail } from "npm:@logtail/node";
const logtail = new Logtail("MY_SOURCE_TOKEN")
logtail.info("test"); // Fails
```

This fails because logtail uses `cross-fetch` which doesn't detect native `fetch` on Deno and instead uses a ponyfill that doesn't work on Deno.

This quick-fix solves the issue but in my opinion there should eventually be a structural solution optimized for Deno that uses the TypeScript modules directly (currently uses CJS modules) and doesn't load any ponyfills that it doesn't need. One option would be `@logtail/deno` but I prefer a unified module for Node, Deno and browsers (and the thousands of other JS runtimes like Cloudflare Workers) that assumes the availability of a global `fetch` function. (be it native or polyfilled)

Anyway, that's why I created a PR here and not in the `cross-fetch` repo. 😉 