### PR TITLE
fix: peerDependencies wrong v. of Bunyan

### DIFF
--- a/packages/bunyan/package.json
+++ b/packages/bunyan/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@logtail/node": "^0.1.0",
-    "bunyan": ">= 2.0.0"
+    "bunyan": ">= 1.8.12"
   },
   "dependencies": {
     "@logtail/types": "^0.1.15"


### PR DESCRIPTION
The version required is not even released... Please refer to: https://www.npmjs.com/package/bunyan