### PR TITLE
Fix broken homepage links

### DIFF
--- a/packages/bunyan/package.json
+++ b/packages/bunyan/package.json
@@ -10,7 +10,7 @@
     "winston"
   ],
   "author": "Logtail <hello@logtail.com>",
-  "homepage": "https://github.com/logtail/logtail-js/tree/master/bunyan#readme",
+  "homepage": "https://github.com/logtail/logtail-js/tree/master/packages/bunyan#readme",
   "license": "ISC",
   "main": "dist/cjs/index.js",
   "module": "dist/es6/index.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -9,7 +9,7 @@
     "Node"
   ],
   "author": "Logtail <hello@logtail.com>",
-  "homepage": "https://github.com/logtail/logtail-js/tree/master/node#readme",
+  "homepage": "https://github.com/logtail/logtail-js/tree/master/packages/node#readme",
   "license": "ISC",
   "main": "dist/cjs/index.js",
   "module": "dist/es6/index.js",

--- a/packages/winston/package.json
+++ b/packages/winston/package.json
@@ -10,7 +10,7 @@
     "winston"
   ],
   "author": "Logtail <hello@logtail.com>",
-  "homepage": "https://github.com/logtail/logtail-js/tree/master/winston#readme",
+  "homepage": "https://github.com/logtail/logtail-js/tree/master/packages/winston#readme",
   "license": "ISC",
   "main": "dist/cjs/index.js",
   "module": "dist/es6/index.js",


### PR DESCRIPTION
While in Logtail Node [NPM page](https://www.npmjs.com/package/@logtail/node) tried navigating to its homepage and got 404. Took a quick look at the remaining packages and saw that Bunyan and Winston also had broken links.