### PR TITLE
Pino: Handle close, do not ignore options 😬

### DIFF
--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -86,6 +86,35 @@ describe("base class tests", () => {
     expect(base.synced).toEqual(1);
   });
 
+  it("should sync after calling flush", async () => {
+    // New Base with very long batch interval and size
+    const base = new Base("testing", { batchInterval: 10000, batchSize: 5 });
+
+    // Create a sync function that resolves after 50ms
+    base.setSync(async log => {
+      return new Promise<ILogtailLog[]>(resolve => {
+        setTimeout(() => {
+          resolve(log);
+        }, 50);
+      });
+    });
+
+    // Fire the log event, and store the pending promise
+    const pending = base.log("Test");
+
+    // The log count should be 1
+    expect(base.logged).toEqual(1);
+
+    // ... but synced should still be zero
+    expect(base.synced).toEqual(0);
+
+    // Trigger flush
+    await base.flush()
+
+    // After flush, synced should be now be 1
+    expect(base.synced).toEqual(1);
+  });
+
   it("should add a pipeline function", async () => {
     // Fixtures
     const firstMessage = "First message";

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -48,6 +48,9 @@ class Logtail {
   // Batch function
   protected _batch: any;
 
+  // Flush function
+  protected _flush: any;
+
   // Middleware
   protected _middleware: Middleware[] = [];
 
@@ -97,9 +100,11 @@ class Logtail {
       this._options.batchInterval
     );
 
-    this._batch = batcher((logs: any) => {
+    this._batch = batcher.initPusher((logs: any) => {
       return throttler(logs);
     });
+
+    this._flush = batcher.flush;
   }
 
   /* PRIVATE METHODS */
@@ -110,6 +115,13 @@ class Logtail {
   }
 
   /* PUBLIC METHODS */
+
+  /**
+   * Flush batched logs to Logtail
+   */
+  public async flush() {
+    return this._flush()
+  }
 
   /**
    * Number of entries logged

--- a/packages/pino/src/pino.ts
+++ b/packages/pino/src/pino.ts
@@ -21,10 +21,9 @@ export interface IPinoLogtailOptions {
 }
 
 export async function logtailTransport(options: IPinoLogtailOptions) {
-  // FIXME: error handling for no source token 
-  const logtail = new Logtail(options.sourceToken)
+  const logtail = new Logtail(options.sourceToken, options.options)
 
-  return build(async (source: any) => {
+  const buildFunc = async (source: any) => {
     for await (let obj of source) {
       // Log should have string `msg` key, > 0 length
       if (typeof obj.msg !== "string" || !obj.msg.length) {
@@ -45,8 +44,8 @@ export async function logtailTransport(options: IPinoLogtailOptions) {
 
       // Carry over any additional data fields
       Object.keys(obj)
-        .filter(key => ["time", "msg", "level", "v"].indexOf(key) < 0)
-        .forEach(key => (meta[key] = obj[key]));
+          .filter(key => ["time", "msg", "level", "v"].indexOf(key) < 0)
+          .forEach(key => (meta[key] = obj[key]));
 
       // Determine the log level
       let level: LogLevel;
@@ -61,5 +60,9 @@ export async function logtailTransport(options: IPinoLogtailOptions) {
       // Log to Logtail
       logtail.log(obj.msg, level, meta);
     }
-  })
+  };
+  const closeFunc = async () => {
+    return await logtail.flush();
+  };
+  return build(buildFunc, { close: closeFunc })
 }

--- a/packages/tools/src/batch.ts
+++ b/packages/tools/src/batch.ts
@@ -60,7 +60,7 @@ export default function makeBatch(
    */
   async function setupTimeout() {
     if (!timeout) {
-      timeout = setTimeout(async function() {
+      timeout = setTimeout(async function () {
         await flush();
       }, flushTimeout);
     }
@@ -70,25 +70,30 @@ export default function makeBatch(
    * Batcher which takes a process function
    * @param fn - Any function to process list
    */
-  return function(fn: Function) {
-    cb = fn;
+  return {
+    initPusher: function (fn: Function) {
+      cb = fn;
 
-    /*
-     * Pushes each log into list
-     * @param log: ILogtailLog - Any object to push into list
-     */
-    return async function(log: ILogtailLog): Promise<ILogtailLog> {
-      return new Promise<ILogtailLog>(async (resolve, reject) => {
-        buffer.push({ log, resolve, reject });
+      /*
+       * Pushes each log into list
+       * @param log: ILogtailLog - Any object to push into list
+       */
+      return async function (log: ILogtailLog): Promise<ILogtailLog> {
+        return new Promise<ILogtailLog>(async (resolve, reject) => {
+          buffer.push({log, resolve, reject});
 
-        if (buffer.length >= size) {
-          await flush();
-        } else {
-          await setupTimeout();
-        }
+          if (buffer.length >= size) {
+            await flush();
+          } else {
+            await setupTimeout();
+          }
 
-        return resolve;
-      });
-    };
+          return resolve;
+        });
+      };
+    },
+    flush: function (): Promise<void> {
+      return flush();
+    }
   };
 }

--- a/packages/tools/src/batch.ts
+++ b/packages/tools/src/batch.ts
@@ -92,8 +92,6 @@ export default function makeBatch(
         });
       };
     },
-    flush: function (): Promise<void> {
-      return flush();
-    }
+    flush
   };
 }


### PR DESCRIPTION
There is a close method that Pino will call on exit. And since Pino uses worker threads we can call async functions in our close function.

Bugfix: do not ignore options.