### PR TITLE
Do not use require

### DIFF
--- a/packages/bunyan/src/bunyan.test.ts
+++ b/packages/bunyan/src/bunyan.test.ts
@@ -132,7 +132,7 @@ describe("Bunyan tests", () => {
     logtail.setSync(async logs => {
       const context = logs[0].context as Context;
       const runtime = context.runtime as Context;
-      expect(runtime.file).toEqual("bunyan.test.ts")
+      expect(runtime.file).toMatch("bunyan.test.ts")
       done();
       return logs;
     });

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -26,7 +26,7 @@ export function getStackContext(logtail: Node, stackContextHint?: StackContextHi
       },
       system: {
         pid: process.pid,
-        main_file: mainfile,
+        main_file: mainFile,
       }
     }
   };

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -3,6 +3,7 @@ import { dirname, relative } from "path";
 import stackTrace, { StackFrame } from 'stack-trace';
 import { Node } from "./node";
 
+const mainfile = mainFileName();
 /**
  * Determines the file name and the line number from which the log
  * was initiated (if we're able to tell).
@@ -25,7 +26,7 @@ export function getStackContext(logtail: Node, stackContextHint?: StackContextHi
       },
       system: {
         pid: process.pid,
-        main_file: mainFileName()
+        main_file: mainfile,
       }
     }
   };
@@ -66,5 +67,16 @@ function relativeToMainModule(fileName: string): string | null {
 }
 
 function mainFileName(): string {
-  return require?.main?.filename ?? '';
+  let argv = process.argv;
+  // return first js file argument - arg ending in .js
+  for (const i in argv) {
+    if (argv[i].startsWith('-')) {
+      // break on first option
+      break;
+    }
+    if (argv[i].endsWith('.js')) {
+      return argv[i];
+    }
+  }
+  return '';
 }

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -3,7 +3,7 @@ import { dirname, relative } from "path";
 import stackTrace, { StackFrame } from 'stack-trace';
 import { Node } from "./node";
 
-const mainfile = mainFileName();
+const mainFile = mainFileName();
 /**
  * Determines the file name and the line number from which the log
  * was initiated (if we're able to tell).

--- a/packages/winston/src/winston.test.ts
+++ b/packages/winston/src/winston.test.ts
@@ -213,6 +213,6 @@ describe("Winston logging tests", () => {
 
     const context = logs[0].context as Context;
     const runtime = context.runtime as Context;
-    expect(runtime.file).toEqual("winston.test.ts")
+    expect(runtime.file).toMatch("winston.test.ts");
   });
 });


### PR DESCRIPTION
Avoid warnings with webpack and when importing in browser.
Fixes: #20

This is a bit hacky way to get rid of the `require`, but **we really don't want our library to produce warnings**.
I haven't found a way to suppress the warnings. Nor I found a better way to get the main file path.

I have tested this with next.js and with node. Both of these work as before. I suspect this change will cause regression In some setups but I don't think it's too important. I considered dropping the main file from the context so with this workaround, we are at least keeping it.

If someone cares about this enough they can explicitly pass main file name as log context.