### PR TITLE
Implement simple retry mechanism

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -23,6 +23,12 @@ const defaultOptions: ILogtailOptions = {
   // Max interval (in milliseconds) before a batch of logs proceeds to syncing
   batchInterval: 1000,
 
+  // Maximum number of times to retry a failed sync request
+  retryCount: 3,
+
+  // Minimum number of milliseconds to wait before retrying a failed sync request
+  retryBackoff: 100,
+
   // Maximum number of sync requests to make concurrently
   syncMax: 5,
 
@@ -101,7 +107,9 @@ class Logtail {
     // Create a batcher, for aggregating logs by buffer size/interval
     const batcher = makeBatch(
       this._options.batchSize,
-      this._options.batchInterval
+      this._options.batchInterval,
+      this._options.retryCount,
+      this._options.retryBackoff
     );
 
     this._batch = batcher.initPusher((logs: any) => {

--- a/packages/tools/src/batch.test.ts
+++ b/packages/tools/src/batch.test.ts
@@ -62,6 +62,25 @@ describe("batch tests", () => {
     done();
   });
 
+  it("should retry 3 times.", async done => {
+    const called = jest.fn();
+    const size = 5;
+    const sendTimeout = 10;
+    const retryCount = 3;
+    const retryBackoff = 1;
+    const err = new Error("test");
+
+    const batcher = makeBatch(size, sendTimeout, retryCount, retryBackoff);
+    const logger = batcher.initPusher(async (batch: ILogtailLog[]) => {
+      called();
+      throw err;
+    });
+
+    await Promise.all(logNumberTimes(logger, 5)).catch(e => {})
+    expect(called).toHaveBeenCalledTimes(4); // 3 retries + 1 initial
+    done();
+  });
+
   it("should play nicely with `throttle`", async () => {
     // Fixtures
     const maxThrottle = 2;

--- a/packages/tools/src/batch.ts
+++ b/packages/tools/src/batch.ts
@@ -87,7 +87,7 @@ export default function makeBatch(
     if (!timeout) {
       timeout = setTimeout(async function () {
         await flush();
-      }, flushTimeout)
+      }, flushTimeout);
     }
   }
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -19,6 +19,16 @@ export interface ILogtailOptions {
   batchInterval: number;
 
   /**
+   * Maximum number of times to retry a failed sync request
+   */
+  retryCount: number;
+
+  /**
+   * Minimum number of milliseconds to wait before retrying a failed sync request
+   */
+  retryBackoff: number;
+
+  /**
    * Maximum number of sync requests to make concurrently (useful to limit
    * network I/O)
    */


### PR DESCRIPTION
Simple retry mechanism.
Waits at minimum `retryBackoff` (100ms default) before retrying.
Retries at most `retryCount` (3 default) times.