### PR TITLE
Allow completely silencing exceptions

### DIFF
--- a/packages/browser/src/browser.test.ts
+++ b/packages/browser/src/browser.test.ts
@@ -40,7 +40,7 @@ describe("browser tests", () => {
   it("should throw error if logtail sends non 200 status code", async done => {
     nock("https://in.logtail.com").post('/').reply(401);
 
-    const browser = new Browser("invalid source token", { ignoreExceptions: false });
+    const browser = new Browser("invalid source token", { ignoreExceptions: false, throwExceptions: true });
     const message: string = String(Math.random);
     await expect(browser.log(message)).rejects.toThrow();
 

--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -46,6 +46,12 @@ describe("base class tests", () => {
     expect(base.synced).toEqual(0);
   });
 
+  it("should default dropped count to zero", () => {
+    const base = new Base("testing");
+
+    expect(base.dropped).toEqual(0);
+  });
+
   it("should increment log count on `.log()`", async () => {
     const base = new Base("testing");
 
@@ -254,11 +260,11 @@ describe("base class tests", () => {
     expect((log as any).stack).toBe(e.stack);
   });
 
-  it("should not ignore exceptions if `ignoreExceptions` opt == false", async () => {
+  it("should not ignore exceptions if `ignoreExceptions` opt == false and `throwExceptions` opt == true", async () => {
     // Fixtures
     const message = "Testing exceptions";
     const e = new Error("Should NOT be ignored!");
-    const base = new Base("testing", { ignoreExceptions: false });
+    const base = new Base("testing", { ignoreExceptions: false, throwExceptions: true });
 
     // Add a mock sync method which throws an error
     base.setSync(async () => {

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -26,8 +26,12 @@ const defaultOptions: ILogtailOptions = {
   // Maximum number of sync requests to make concurrently
   syncMax: 5,
 
-  // If true, errors/failed logs should be ignored
-  ignoreExceptions: true,
+  // If true, errors when sending logs will be ignored
+  // Has precedence over throwExceptions
+  ignoreExceptions: false,
+
+  // If true, errors when sending logs will result in a thrown exception
+  throwExceptions: false,
 
   // maximum depth (number of attribute levels) of a context object
   contextObjectMaxDepth: 50,
@@ -66,6 +70,9 @@ class Logtail {
 
   // Number of logs successfully synced with Logtail
   private _countSynced = 0;
+
+  // Number of logs that failed to be synced to Logtail
+  private _countDropped = 0;
 
   /* CONSTRUCTOR */
 
@@ -146,6 +153,15 @@ class Logtail {
   }
 
   /**
+   * Number of entries dropped
+   *
+   * @returns number
+   */
+  public get dropped(): number {
+    return this._countDropped;
+  }
+
+  /**
    * Log an entry, to be synced with Logtail.com
    *
    * @param message: string - Log message
@@ -219,11 +235,17 @@ class Logtail {
       // Increment sync count
       this._countSynced++;
     } catch (e) {
+      // Increment dropped count
+      this._countDropped++;
+
       // Catch any errors - re-throw if `ignoreExceptions` == false
       if (!this._options.ignoreExceptions) {
-        throw e;
-      } else {
-        console.error(e);
+        if (this._options.throwExceptions) {
+          throw e;
+        } else {
+          // Output to console
+          console.error(e);
+        }
       }
     }
 

--- a/packages/node/src/node.test.ts
+++ b/packages/node/src/node.test.ts
@@ -37,7 +37,7 @@ describe("node tests", () => {
       .post('/')
       .reply(401);
 
-    const node = new Node("invalid source token", { ignoreExceptions: false });
+    const node = new Node("invalid source token", { ignoreExceptions: false, throwExceptions: true });
     const message: string = String(Math.random);
     await expect(node.log(message)).rejects.toThrow();
   });

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -25,10 +25,15 @@ export interface ILogtailOptions {
   syncMax: number;
 
   /**
-   * Boolean to specify whether thrown errors/failed logs should be ignored
+   * Errors when sending logs will be silently ignored
+   * Has precedence over throwExceptions
    */
   ignoreExceptions: boolean;
 
+  /**
+   * Errors when sending logs will result in thrown exceptions
+   */
+  throwExceptions: boolean;
 
   /**
    * Maximum depth (number of attribute levels) of a context object


### PR DESCRIPTION
Changes meaning of `ignoreExceptions` but not in a dangerous way.
Before, `ignoreExceptions` printed exceptions. Now, it ignores them completely.
The default behavior stayed the same.
