### PR TITLE
Improve deno support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,5 +6,5 @@ We are using `yarn` to manage dependencies.
 2. Run `yarn bootstrap` to install and cross-link packages in `packages/*`
 3. To run tests
    1. Run `yarn test` to run all tests
-   2. To run tests for a single package use `yarn test package/node` to run tests only from the node package for example
-4. Run `npx lerna build` to build all packages
+   2. To run tests for a single package use `yarn test packages/node` to run tests only from the node package for example
+4. Run `yarn build` to build all packages

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -70,13 +70,13 @@ function mainFileName(): string {
   let argv = process?.argv;
   if (argv === undefined) return '';
   // return first js file argument - arg ending in .js
-  for (const i in argv) {
-    if (typeof(argv[i]) !== "string" || argv[i].startsWith('-')) {
+  for (const arg of argv) {
+    if (typeof(arg) !== "string" || arg.startsWith('-')) {
       // break on first option
       break;
     }
-    if (argv[i].endsWith('.js')) {
-      return argv[i];
+    if (arg.endsWith('.js')) {
+      return arg;
     }
   }
   return '';


### PR DESCRIPTION
Hi, I'm trying to make `logtail/node` work in Deno Deploy via esm.sh like so:
```ts
import { Logtail } from "https://esm.sh/@logtail/node@0.4.0"
```

I'm running into an error which seems to come from an unsafe way of iterating through `process.argv`, which accesses all properties of the object and not just its array values:
```ts
for (const i in argv) {
```

This PR should fix this by iterating via `for..of` instead of `for..in`.

I also fixed a couple of inaccuracies in CONTRIBUTING.md.


<details>
  <summary>For reference, here's the error</summary>

  ```js
  TypeError: Cannot read properties of undefined (reading 'startsWith')
      at Array.get (https://deno.land/std@0.177.0/node/process.ts:51:29)
      at d (https://esm.sh/v117/@logtail/node@0.4.0/X-a24KaWE/deno/node.mjs:2:1502)
      at https://esm.sh/v117/@logtail/node@0.4.0/X-a24KaWE/deno/node.mjs:2:579
  ```
</details>