### PR TITLE
Implement configurable burst protection

### DIFF
--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -482,9 +482,8 @@ describe("base class tests", () => {
 
     const logs = [];
     for (let i = 0; i < 500; i++) {
-      logs.push(base.info(message));
-      // Wait for 1ms after every log
-      await new Promise(resolve => setTimeout(resolve, 1));
+      // Send logs with 1ms delay between them
+      logs.push(new Promise(resolve => { setTimeout(() => base.info(message).then(resolve), i) }))
     }
 
     await Promise.all(logs);

--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -293,6 +293,34 @@ describe("base class tests", () => {
     expect(log.message).toBe(message);
   });
 
+  it("should sync all logs in single call", async () => {
+    // Fixtures
+    const message = "Testing logging";
+    const base = new Base("testing");
+
+    // Add a mock sync method which counts sync calls and sent logs
+    let syncCount = 0;
+    let logsCount = 0;
+    base.setSync(async (logs) => {
+      syncCount++;
+      logsCount = logs.length;
+      return logs;
+    });
+
+    await Promise.all([
+      base.debug(message),
+      base.info(message),
+      base.warn(message),
+      base.error(message),
+    ]);
+
+    // Should sync all logs in single call
+    expect(syncCount).toBe(1);
+    expect(logsCount).toBe(4);
+    expect(base.synced).toBe(4);
+    expect(base.logged).toBe(4);
+  });
+
   it("should not send any logs to Better Stack when sendLogsToBetterStack=false", async () => {
     // Fixtures
     const message = "Testing logging";
@@ -300,10 +328,10 @@ describe("base class tests", () => {
       sendLogsToBetterStack: false
     });
 
-    // Add a mock sync method which counts synced logs
-    let logsSynced = 0
+    // Add a mock sync method which counts sync calls
+    let syncCount = 0
     base.setSync(async (log) => {
-      logsSynced++;
+      syncCount++;
       return log;
     });
 
@@ -315,10 +343,12 @@ describe("base class tests", () => {
     await base.log(message, "http");
     await base.log(message, "verbose");
     await base.log(message, "silly");
-    // await base.log(message, "trace");
+    await base.log(message, "trace");
 
     // Should sync no logs
-    expect(logsSynced).toBe(0);
+    expect(syncCount).toBe(0);
+    expect(base.synced).toBe(0);
+    expect(base.logged).toBe(9);
   });
 
   it("should send all logs to console output when sendLogsToConsoleOutput=true", async () => {
@@ -354,7 +384,7 @@ describe("base class tests", () => {
     await base.log(message, "silly");
     await base.log(message, "trace");
 
-    // Should sync no logs
+    // Should forward all logs to console output
     expect(consoleOutputs).toEqual([
       ["debug", "Testing logging", {}],
       ["info", "Testing logging", {}],
@@ -366,6 +396,8 @@ describe("base class tests", () => {
       ["log", "[SILLY]", "Testing logging", {}],
       ["log", "[TRACE]", "Testing logging", {}],
     ]);
+    expect(base.synced).toBe(9);
+    expect(base.logged).toBe(9);
 
     console = originalConsole
   });

--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -490,9 +490,11 @@ describe("base class tests", () => {
 
     console.error = originalConsoleError;
 
-    // Should sync only half the logs
-    expect(base.synced).toBe(250);
-    expect(base.logged).toBe(250);
+    // Should sync only approximately half the logs
+    expect(base.synced).toBeGreaterThan(240);
+    expect(base.synced).toBeLessThan(260);
+    expect(base.logged).toBeGreaterThan(240);
+    expect(base.logged).toBeLessThan(260);
 
     expect(mockedConsoleError).toHaveBeenCalledWith("Logging was called more than 50 times during last 100ms. Ignoring.");
     expect(mockedConsoleError).toHaveBeenCalledTimes(5);

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -32,6 +32,12 @@ const defaultOptions: ILogtailOptions = {
   // Maximum number of sync requests to make concurrently
   syncMax: 5,
 
+  // Length of the checked window for logs burst protection in milliseconds (0 to disable)
+  burstProtectionMilliseconds: 5000,
+
+  // Maximum number of accepted logs in the specified time window (0 to disable)
+  burstProtectionMax: 10000,
+
   // If true, errors when sending logs will be ignored
   // Has precedence over throwExceptions
   ignoreExceptions: false,
@@ -121,7 +127,11 @@ class Logtail {
     });
 
     // Burst protection for logging
-    this._logBurstProtection = makeBurstProtection(5000, 10000, 'Logging')
+    this._logBurstProtection = makeBurstProtection(
+        this._options.burstProtectionMilliseconds,
+        this._options.burstProtectionMax,
+        'Logging',
+    )
     this.log = this._logBurstProtection(this.log.bind(this))
 
     // Create a batcher, for aggregating logs by buffer size/interval

--- a/packages/tools/src/burstProtection.ts
+++ b/packages/tools/src/burstProtection.ts
@@ -1,0 +1,46 @@
+import { InferArgs } from "./types";
+
+const RESOLUTION = 100;
+
+/**
+ * Create a burst protection which allows running function only a number of times in a configurable window
+ * @param milliseconds - length of the checked window in milliseconds
+ * @param max - maximum number of functions to run in that window
+ * @param functionName - function name for error message
+ */
+export default function makeBurstProtection<T extends (...args: any[]) => any>(
+  milliseconds: number,
+  max: number,
+  functionName: string = 'The function',
+) {
+  let callCounts: number[] = [0];
+  let lastErrorOutput: number = 0;
+
+  setInterval(() => {
+    callCounts = callCounts.slice(0, RESOLUTION - 1)
+    callCounts.unshift(0)
+  }, milliseconds / RESOLUTION)
+
+  function getTotalCallCount() {
+    return callCounts.reduce((total, item) => total + item);
+  }
+
+  function incrementCallCount() {
+    callCounts[0]++
+  }
+
+  return (fn: T) => {
+    return async (...args: InferArgs<T>[]) => {
+      if (getTotalCallCount() < max) {
+        incrementCallCount();
+        return await fn(...args)
+      }
+
+      const now = Date.now()
+      if (lastErrorOutput < now - milliseconds) {
+        lastErrorOutput = now
+        console.error(`${functionName} was called more than ${max} times during last ${milliseconds}ms. Ignoring.`)
+      }
+    };
+  };
+}

--- a/packages/tools/src/burstProtection.ts
+++ b/packages/tools/src/burstProtection.ts
@@ -13,6 +13,10 @@ export default function makeBurstProtection<T extends (...args: any[]) => any>(
   max: number,
   functionName: string = 'The function',
 ) {
+  if (milliseconds <= 0 || max <= 0) {
+    return (fn: T) => fn
+  }
+
   let callCounts: number[] = [0];
   let lastErrorOutput: number = 0;
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -2,6 +2,7 @@ import { IQueue } from "./types";
 import Queue from "./queue";
 import { base64Encode } from "./encode";
 import makeBatch from "./batch";
+import makeBurstProtection from "./burstProtection";
 import makeThrottle from "./throttle";
 
 export {
@@ -12,5 +13,6 @@ export {
   // Functions
   base64Encode,
   makeBatch,
+  makeBurstProtection,
   makeThrottle
 };

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -35,6 +35,16 @@ export interface ILogtailOptions {
   syncMax: number;
 
   /**
+   * Length of the checked window for logs burst protection in milliseconds (0 to disable)
+   */
+  burstProtectionMilliseconds: number;
+
+  /**
+   * Maximum number of accepted logs in the specified time window (0 to disable)
+   */
+  burstProtectionMax: number;
+
+  /**
    * Errors when sending logs will be silently ignored
    * Has precedence over throwExceptions
    */


### PR DESCRIPTION
https://trello.com/c/UMhr1tn6/1656-clientsjs-implement-buffer-overflow-burst-protection

Adds configurable burst protection to limit the amount of logs. Implemented in such a way as to not hinder performance. Default values are quite permissive as at this point, we have no limits in place (10000 logs in 5 seconds).

New Logger options:
- `burstProtectionMilliseconds:number`
  Length of the checked window for logs burst protection in milliseconds
  Default: 5000
- `burstProtectionMax:number`
  Maximum number of accepted logs in the specified time window
  Default: 10000