### PR TITLE
Wrap context and use sanitizeContext in Browser as well

### DIFF
--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,6 +1,6 @@
 import fetch from "cross-fetch";
 
-import {Context, ILogLevel, ILogtailLog, ILogtailOptions, StackContextHint} from "@logtail/types";
+import { Context, ILogLevel, ILogtailLog, ILogtailOptions } from "@logtail/types";
 import { Base } from "@logtail/core";
 import { sanitizeContext } from "@logtail/tools";
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@logtail/core": "^0.4.5",
+    "@logtail/tools": "^0.4.5",
     "@logtail/types": "^0.4.5",
     "@msgpack/msgpack": "^2.5.1",
     "@types/stack-trace": "^0.0.29",

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -3,8 +3,9 @@ import {Duplex, Writable} from "stream";
 import fetch from "cross-fetch";
 import {encode} from "@msgpack/msgpack";
 
-import {Context, ILogLevel, ILogtailLog, ILogtailOptions, LogLevel, StackContextHint} from "@logtail/types";
+import {Context, ILogLevel, ILogtailLog, ILogtailOptions, StackContextHint} from "@logtail/types";
 import {Base} from "@logtail/core";
+import {sanitizeContext} from "@logtail/tools";
 
 import {getStackContext} from "./context";
 
@@ -95,68 +96,9 @@ export class Node extends Base {
   }
 
   private encodeAsMsgpack(logs: ILogtailLog[]): Buffer {
-    const maxDepth = this._options.contextObjectMaxDepth;
-    const logsWithISODateFormat = logs.map((log) => ({ ...this.sanitizeForEncoding(log, maxDepth), dt: log.dt.toISOString() }));
+    const logsWithISODateFormat = logs.map((log) => ({ ...sanitizeContext(log, this._options), dt: log.dt.toISOString() }));
     const encoded = encode(logsWithISODateFormat);
     const buffer = Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength)
     return buffer;
-  }
-
-  private sanitizeForEncoding(value: any, maxDepth: number, visitedObjects: WeakSet<any> = new WeakSet()): any {
-    if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
-      return value;
-    } else if (value instanceof Date) {
-      // Date instances can be invalid & toISOString() will fail
-      if (isNaN(value.getTime())) {
-        return value.toString();
-      }
-
-      return value.toISOString();
-    } else if (value instanceof Error) {
-      return {
-        name: value.name,
-        message: value.message,
-        stack: value.stack?.split("\n"),
-      };
-    } else if ((typeof value === "object" || Array.isArray(value)) && (maxDepth < 1 || visitedObjects.has(value))) {
-      if (visitedObjects.has(value)) {
-        if (this._options.contextObjectCircularRefWarn) {
-          console.warn(`[Logtail] Found a circular reference when serializing logs. Please do not use circular references in your logs.`);
-        }
-        return '<omitted circular reference>'
-      }
-      if (this._options.contextObjectMaxDepthWarn) {
-        console.warn(`[Logtail] Max depth of ${this._options.contextObjectMaxDepth} reached when serializing logs. Please do not use excessive object depth in your logs.`);
-      }
-      return `<omitted context beyond configured max depth: ${this._options.contextObjectMaxDepth}>`
-    } else if (Array.isArray(value)) {
-      visitedObjects.add(value);
-      const sanitizedArray = value.map((item) => this.sanitizeForEncoding(item, maxDepth-1, visitedObjects));
-      visitedObjects.delete(value);
-
-      return sanitizedArray
-    } else if (typeof value === "object") {
-      const logClone: { [key: string]: any } = {};
-
-      visitedObjects.add(value);
-
-      Object.entries(value).forEach(item => {
-        const key = item[0];
-        const value = item[1];
-
-        const result = this.sanitizeForEncoding(value, maxDepth-1, visitedObjects);
-        if (result !== undefined){
-          logClone[key] = result;
-        }
-      });
-
-      visitedObjects.delete(value);
-
-      return logClone;
-    } else if (typeof value === 'undefined') {
-      return undefined;
-    } else {
-      return `<omitted unserializable ${typeof value}>`;
-    }
   }
 }

--- a/packages/tools/src/encode.test.ts
+++ b/packages/tools/src/encode.test.ts
@@ -1,4 +1,5 @@
-import { base64Encode } from "./encode";
+import {base64Encode, sanitizeContext} from "./encode";
+import {ILogtailOptions} from "@logtail/types";
 
 describe("Encode function tests", () => {
   // Fixtures
@@ -7,5 +8,70 @@ describe("Encode function tests", () => {
 
   it("should convert plain text to base64", () => {
     expect(base64Encode(ascii)).toEqual(base64);
+  });
+});
+
+describe("Function sanitizeContext", () => {
+  // Fixtures
+  const options: ILogtailOptions = {
+    endpoint: "https://in.logtail.com",
+    batchSize: 1000,
+    batchInterval: 1000,
+    retryCount: 3,
+    retryBackoff: 100,
+    syncMax: 5,
+    burstProtectionMilliseconds: 5000,
+    burstProtectionMax: 10000,
+    ignoreExceptions: false,
+    throwExceptions: false,
+    contextObjectMaxDepth: 3,
+    contextObjectMaxDepthWarn: false,
+    contextObjectCircularRefWarn: false,
+    sendLogsToConsoleOutput: false,
+    sendLogsToBetterStack: true,
+  };
+
+  it("should keep string as is", () => {
+    expect(sanitizeContext("my string", options)).toEqual("my string");
+  });
+
+  it("should keep number as is", () => {
+    expect(sanitizeContext(123.456, options)).toEqual(123.456);
+  });
+
+  it("should keep boolean as is", () => {
+    expect(sanitizeContext(true, options)).toEqual(true);
+  });
+
+  it("should keep array", () => {
+    expect(sanitizeContext([1,2,3], options)).toEqual([1,2,3]);
+  });
+
+  it("should format dates in UTC", () => {
+    expect(sanitizeContext(new Date("2015-03-14T12:30:00.001+08:00"), options)).toEqual("2015-03-14T04:30:00.001Z");
+  });
+
+  it("should keep shallow object as is", () => {
+    expect(sanitizeContext({foo: "bar", nested: {a: 1, b: 2}}, options))
+        .toEqual({foo: "bar", nested: {a: 1, b: 2}});
+  });
+
+  it("should serialize details of Errors", () => {
+    const sanitizedError = sanitizeContext(new Error("My testing error"), options)
+    expect(sanitizedError.name).toEqual("Error");
+    expect(sanitizedError.message).toEqual("My testing error");
+    expect(sanitizedError.stack).toBeInstanceOf(Array);
+  });
+
+  it("should truncate deep object", () => {
+    expect(sanitizeContext({very: {deeply: {nested: {object: {}}}}}, options))
+        .toEqual({very: {deeply: {nested: "<omitted context beyond configured max depth: 3>"}}});
+  });
+
+  it("should omit circular dependencies", () => {
+    const batman = {name: "Batman", sidekick: {}};
+    batman.sidekick = {name: "Robin", hero: batman};
+    expect(sanitizeContext(batman, options))
+        .toEqual({name: "Batman", sidekick: {name: "Robin", hero: "<omitted circular reference>"}});
   });
 });

--- a/packages/tools/src/encode.ts
+++ b/packages/tools/src/encode.ts
@@ -1,3 +1,5 @@
+import { ILogtailOptions } from "@logtail/types";
+
 /**
  * Converts a plain-text string to a base64 string
  *
@@ -5,4 +7,74 @@
  */
 export function base64Encode(str: string): string {
   return Buffer.from(str).toString("base64");
+}
+
+/**
+ * Sanitizes context values before serialization
+ *
+ * @param value - Context value for sanitizing before encoding
+ * @param options - Logtail options determining limits and warning behavior
+ * @param maxDepth - Depth counter for maxDepth check
+ * @param visitedObjects - Visited object map for circularDependency check
+ */
+export function sanitizeContext(value: any, options: ILogtailOptions, maxDepth?: number, visitedObjects: WeakSet<any> = new WeakSet()): any {
+  if (maxDepth === undefined) {
+    return sanitizeContext(value, options, options.contextObjectMaxDepth)
+  }
+
+  if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    return value;
+  } else if (value instanceof Date) {
+    // Date instances can be invalid & toISOString() will fail
+    if (isNaN(value.getTime())) {
+      return value.toString();
+    }
+
+    return value.toISOString();
+  } else if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack?.split("\n"),
+    };
+  } else if ((typeof value === "object" || Array.isArray(value)) && (maxDepth < 1 || visitedObjects.has(value))) {
+    if (visitedObjects.has(value)) {
+      if (options.contextObjectCircularRefWarn) {
+        console.warn(`[Logtail] Found a circular reference when serializing logs. Please do not use circular references in your logs.`);
+      }
+      return '<omitted circular reference>'
+    }
+    if (options.contextObjectMaxDepthWarn) {
+      console.warn(`[Logtail] Max depth of ${options.contextObjectMaxDepth} reached when serializing logs. Please do not use excessive object depth in your logs.`);
+    }
+    return `<omitted context beyond configured max depth: ${options.contextObjectMaxDepth}>`
+  } else if (Array.isArray(value)) {
+    visitedObjects.add(value);
+    const sanitizedArray = value.map((item) => sanitizeContext(item, options, maxDepth-1, visitedObjects));
+    visitedObjects.delete(value);
+
+    return sanitizedArray
+  } else if (typeof value === "object") {
+    const logClone: { [key: string]: any } = {};
+
+    visitedObjects.add(value);
+
+    Object.entries(value).forEach(item => {
+      const key = item[0];
+      const value = item[1];
+
+      const result = sanitizeContext(value, options, maxDepth-1, visitedObjects);
+      if (result !== undefined){
+        logClone[key] = result;
+      }
+    });
+
+    visitedObjects.delete(value);
+
+    return logClone;
+  } else if (typeof value === 'undefined') {
+    return undefined;
+  } else {
+    return `<omitted unserializable ${typeof value}>`;
+  }
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,6 +1,6 @@
 import { IQueue } from "./types";
 import Queue from "./queue";
-import { base64Encode } from "./encode";
+import { base64Encode, sanitizeContext } from "./encode";
 import makeBatch from "./batch";
 import makeBurstProtection from "./burstProtection";
 import makeThrottle from "./throttle";
@@ -12,6 +12,7 @@ export {
   Queue,
   // Functions
   base64Encode,
+  sanitizeContext,
   makeBatch,
   makeBurstProtection,
   makeThrottle


### PR DESCRIPTION
Builds on top of #71 

This PR ensures similar behavior in Browser as was implemented for Node in #13 and #34.