### PR TITLE
[bunyan] Use message field as message

### DIFF
--- a/packages/bunyan/src/bunyan.ts
+++ b/packages/bunyan/src/bunyan.ts
@@ -48,7 +48,7 @@ export class LogtailStream extends Writable {
     // Get message
     // NOTE: Bunyan passes empty 'msg' when msg is missing
     const use_msg_field = log.msg !== undefined && log.msg.length > 0;
-    let msg = use_msg_field ? log.msg : log.message;
+    const msg = (use_msg_field ? log.msg : log.message) || "<no message provided>";
 
     // Prevent overriding 'message' with 'msg'
     // Save 'message' as 'message_field' if we are using 'msg' as message


### PR DESCRIPTION
Logging without message as a separate argument was completely ignored before - e.g. this would produce no log in Live tail:
```
logger.info({ msg: "Message", moreContext: "more info" })
```

This PR:
- allows logs without message argument
- uses 'message' field if message argument is missing

Known issue:
Bunyan completely ignores 'msg' field passed inside the context object. I.e. you are not supposed to log like this: `logger.({ msg: "Message" })`
Some issues about that here:
https://github.com/trentm/node-bunyan/issues/515#issuecomment-1702682901
https://github.com/trentm/node-bunyan/issues/517


