### PR TITLE
Add `yarn lint` to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
+            packages/browser/yarn.lock
+            packages/bunyan/yarn.lock
+            packages/core/yarn.lock
+            packages/js/yarn.lock
+            packages/koa/yarn.lock
+            packages/node/yarn.lock
+            packages/tools/yarn.lock
+            packages/types/yarn.lock
+            packages/winston/yarn.lock
+
+      - name: Setup yarn
+        run: npm install -g yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run lint
+        run: yarn lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+dist/
 .gitignore
 .npmignore
 *.map
+yarn.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/browser/src/browser.test.ts
+++ b/packages/browser/src/browser.test.ts
@@ -9,7 +9,7 @@ import { Browser } from "./browser";
  */
 function getRandomLog(message: string): Partial<ILogtailLog> {
   return {
-    message
+    message,
   };
 }
 
@@ -26,7 +26,9 @@ describe("browser tests", () => {
   // });
 
   it("should echo log if logtail sends 20x status code", async done => {
-    nock("https://in.logtail.com").post('/').reply(201);
+    nock("https://in.logtail.com")
+      .post("/")
+      .reply(201);
 
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
@@ -38,9 +40,14 @@ describe("browser tests", () => {
   });
 
   it("should throw error if logtail sends non 200 status code", async done => {
-    nock("https://in.logtail.com").post('/').reply(401);
+    nock("https://in.logtail.com")
+      .post("/")
+      .reply(401);
 
-    const browser = new Browser("invalid source token", { ignoreExceptions: false, throwExceptions: true });
+    const browser = new Browser("invalid source token", {
+      ignoreExceptions: false,
+      throwExceptions: true,
+    });
     const message: string = String(Math.random);
     await expect(browser.log(message)).rejects.toThrow();
 

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,4 +1,4 @@
-import 'cross-fetch/polyfill';
+import "cross-fetch/polyfill";
 
 import { ILogtailLog, ILogtailOptions } from "@logtail/types";
 import { Base } from "@logtail/core";
@@ -7,28 +7,22 @@ import { Base } from "@logtail/core";
 // import { getUserAgent } from "./helpers";
 
 export class Browser extends Base {
-  public constructor(
-    sourceToken: string,
-    options?: Partial<ILogtailOptions>
-  ) {
+  public constructor(sourceToken: string, options?: Partial<ILogtailOptions>) {
     super(sourceToken, options);
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
-      const res = await fetch(
-        this._options.endpoint,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this._sourceToken}`
-            // Awaiting: https://bugs.chromium.org/p/chromium/issues/detail?id=571722
-            // "User-Agent": getUserAgent()
-          },
-          body: JSON.stringify(logs),
-          keepalive: true,
-        }
-      );
+      const res = await fetch(this._options.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this._sourceToken}`,
+          // Awaiting: https://bugs.chromium.org/p/chromium/issues/detail?id=571722
+          // "User-Agent": getUserAgent()
+        },
+        body: JSON.stringify(logs),
+        keepalive: true,
+      });
 
       if (res.ok) {
         return logs;
@@ -48,12 +42,12 @@ export class Browser extends Base {
   }
 
   private configureFlushOnPageLeave() {
-    if (typeof document === 'undefined') {
+    if (typeof document === "undefined") {
       return;
     }
 
-    document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'hidden') {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") {
         this.flush();
       }
     });

--- a/packages/browser/src/umd.ts
+++ b/packages/browser/src/umd.ts
@@ -1,3 +1,2 @@
 import { Browser } from "./browser";
-
 (window as any).Logtail = Browser;

--- a/packages/browser/webpack.config.ts
+++ b/packages/browser/webpack.config.ts
@@ -8,10 +8,10 @@ const umdConfig: webpack.Configuration = {
   output: {
     libraryTarget: "umd",
     path: path.join(__dirname, "dist", "umd"),
-    filename: "logtail.js"
+    filename: "logtail.js",
   },
   optimization: {
-    usedExports: true
+    usedExports: true,
   },
   module: {
     rules: [
@@ -21,14 +21,14 @@ const umdConfig: webpack.Configuration = {
         options: {
           transpileOnly: true,
           context: __dirname,
-          configFile: "tsconfig.umd.json"
-        }
-      }
-    ]
+          configFile: "tsconfig.umd.json",
+        },
+      },
+    ],
   },
   resolve: {
-    extensions: [".ts", ".js"]
-  }
+    extensions: [".ts", ".js"],
+  },
 };
 
 export default umdConfig;

--- a/packages/bunyan/README.md
+++ b/packages/bunyan/README.md
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/bunyan)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/bunyan/src/bunyan.test.ts
+++ b/packages/bunyan/src/bunyan.test.ts
@@ -21,9 +21,9 @@ function createLogger(logtail: Logtail): bunyan {
     level: "debug", // <-- default to 'debug' and above
     streams: [
       {
-        stream: new LogtailStream(logtail)
-      }
-    ]
+        stream: new LogtailStream(logtail),
+      },
+    ],
   });
 }
 
@@ -37,7 +37,7 @@ function createLogger(logtail: Logtail): bunyan {
 async function testLevel(
   level: LogLevelString,
   logLevel: LogLevel,
-  cb: Function
+  cb: Function,
 ) {
   // Logtail fixtures
   const logtail = new Logtail("test", { batchInterval: 1 });
@@ -92,12 +92,12 @@ describe("Bunyan tests", () => {
       [30, LogLevel.Info, "info"],
       [40, LogLevel.Warn, "warn"],
       [50, LogLevel.Error, "error"],
-      [60, LogLevel.Fatal, "fatal"]
+      [60, LogLevel.Fatal, "fatal"],
     ];
 
     const logtail = new Logtail("test", {
       batchInterval: 1000,
-      batchSize: levels.length
+      batchSize: levels.length,
     });
 
     logtail.setSync(async logs => {
@@ -131,7 +131,7 @@ describe("Bunyan tests", () => {
     const logtail = new Logtail("test");
     logtail.setSync(async logs => {
       const context = logs[0].context;
-      expect(context.runtime.file).toMatch("bunyan.test.ts")
+      expect(context.runtime.file).toMatch("bunyan.test.ts");
       done();
       return logs;
     });

--- a/packages/bunyan/src/bunyan.ts
+++ b/packages/bunyan/src/bunyan.ts
@@ -1,9 +1,12 @@
 import { Writable } from "stream";
 
 import { Logtail } from "@logtail/node";
-import {Context, LogLevel, StackContextHint} from "@logtail/types";
+import { Context, LogLevel, StackContextHint } from "@logtail/types";
 
-const stackContextHint = { fileName: "node_modules/bunyan", methodNames: [ "fatal", "error", "warn", "info", "debug", "trace" ] };
+const stackContextHint = {
+  fileName: "node_modules/bunyan",
+  methodNames: ["fatal", "error", "warn", "info", "debug", "trace"],
+};
 
 import { getLogLevel } from "./helpers";
 
@@ -48,7 +51,8 @@ export class LogtailStream extends Writable {
     // Get message
     // NOTE: Bunyan passes empty 'msg' when msg is missing
     const use_msg_field = log.msg !== undefined && log.msg.length > 0;
-    const msg = (use_msg_field ? log.msg : log.message) || "<no message provided>";
+    const msg =
+      (use_msg_field ? log.msg : log.message) || "<no message provided>";
 
     // Prevent overriding 'message' with 'msg'
     // Save 'message' as 'message_field' if we are using 'msg' as message
@@ -60,7 +64,12 @@ export class LogtailStream extends Writable {
     const level = getLogLevel(log.level);
 
     // Log to Logtail
-    void this._logtail.log(msg, level, meta, stackContextHint as StackContextHint);
+    void this._logtail.log(
+      msg,
+      level,
+      meta,
+      stackContextHint as StackContextHint,
+    );
 
     next();
   }

--- a/packages/bunyan/src/helpers.ts
+++ b/packages/bunyan/src/helpers.ts
@@ -7,7 +7,7 @@ import { LogLevel, ILogLevel } from "@logtail/types";
 export function getLogLevel(level: number | string): ILogLevel {
   // Are we dealing with a string log level?
   if (typeof level === "string") {
-    return level.toLowerCase()
+    return level.toLowerCase();
   }
   if (typeof level === "number") {
     // Trace

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -27,10 +27,7 @@ import { ILogtailOptions, ILogtailLog } from "@logtail/types";
 
 class CustomLogger extends Base {
   // Constructor must take a Logtail.com source token, and (optional) options
-  public constructor(
-    sourceToken: string,
-    options?: Partial<ILogtailOptions>
-  ) {
+  public constructor(sourceToken: string, options?: Partial<ILogtailOptions>) {
     // Make sure you pass the source token to the parent constructor!
     super(sourceToken, options);
 
@@ -80,7 +77,7 @@ All log levels return a Promise that will resolve once the log has been synced w
 
 ```typescript
 // Will resolve when synced with Logtail.com (or reject if there's an error)
-logtail.log("some log message").then((log) => {
+logtail.log("some log message").then(log => {
   // `log` is the transformed log, after going through middleware
 });
 ```

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -3,8 +3,8 @@ module.exports = {
   coveragePathIgnorePatterns: ["/node_modules/", "/dist/"],
   globals: {
     "ts-jest": {
-      tsConfig: "tsconfig.json"
-    }
+      tsConfig: "tsconfig.json",
+    },
   },
   moduleDirectories: ["node_modules"],
   moduleFileExtensions: ["ts", "tsx", "js"],
@@ -12,6 +12,6 @@ module.exports = {
   testMatch: ["**/*.test.ts"],
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
   transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest"
-  }
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
 };

--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -115,7 +115,7 @@ describe("base class tests", () => {
     expect(base.synced).toEqual(0);
 
     // Trigger flush
-    await base.flush()
+    await base.flush();
 
     // After flush, synced should be now be 1
     expect(base.synced).toEqual(1);
@@ -136,7 +136,7 @@ describe("base class tests", () => {
     base.use(async log => {
       return {
         ...log,
-        message: newMessage
+        message: newMessage,
       };
     });
 
@@ -264,7 +264,10 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing exceptions";
     const e = new Error("Should NOT be ignored!");
-    const base = new Base("testing", { ignoreExceptions: false, throwExceptions: true });
+    const base = new Base("testing", {
+      ignoreExceptions: false,
+      throwExceptions: true,
+    });
 
     // Add a mock sync method which throws an error
     base.setSync(async () => {
@@ -278,7 +281,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing exceptions";
     const base = new Base("testing", {
-      ignoreExceptions: true
+      ignoreExceptions: true,
     });
 
     // Add a mock sync method which throws an error
@@ -301,7 +304,7 @@ describe("base class tests", () => {
     // Add a mock sync method which counts sync calls and sent logs
     let syncCount = 0;
     let logsCount = 0;
-    base.setSync(async (logs) => {
+    base.setSync(async logs => {
       syncCount++;
       logsCount = logs.length;
       return logs;
@@ -325,12 +328,12 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing logging";
     const base = new Base("testing", {
-      sendLogsToBetterStack: false
+      sendLogsToBetterStack: false,
     });
 
     // Add a mock sync method which counts sync calls
-    let syncCount = 0
-    base.setSync(async (log) => {
+    let syncCount = 0;
+    base.setSync(async log => {
       syncCount++;
       return log;
     });
@@ -363,8 +366,8 @@ describe("base class tests", () => {
     base.setSync(async log => log);
 
     // Mock console methods
-    const originalConsole = console
-    const consoleOutputs:any = []
+    const originalConsole = console;
+    const consoleOutputs: any = [];
     console = {
       ...console,
       debug: (...args: any) => consoleOutputs.push(["debug", ...args]),
@@ -372,7 +375,7 @@ describe("base class tests", () => {
       warn: (...args: any) => consoleOutputs.push(["warn", ...args]),
       error: (...args: any) => consoleOutputs.push(["error", ...args]),
       log: (...args: any) => consoleOutputs.push(["log", ...args]),
-    }
+    };
 
     await base.debug(message);
     await base.info(message);
@@ -399,7 +402,7 @@ describe("base class tests", () => {
     expect(base.synced).toBe(9);
     expect(base.logged).toBe(9);
 
-    console = originalConsole
+    console = originalConsole;
   });
 
   it("should limit sent requests", async () => {
@@ -432,14 +435,19 @@ describe("base class tests", () => {
     expect(base.synced).toBe(10000);
     expect(base.logged).toBe(10000);
 
-    expect(mockedConsoleError).toHaveBeenCalledWith("Logging was called more than 10000 times during last 5000ms. Ignoring.");
+    expect(mockedConsoleError).toHaveBeenCalledWith(
+      "Logging was called more than 10000 times during last 5000ms. Ignoring.",
+    );
     expect(mockedConsoleError).toHaveBeenCalledTimes(1);
   });
 
   it("should not limit sent requests if not exceeding burst protection limits", async () => {
     // Fixtures
     const message = "Testing logging";
-    const base = new Base("testing", { burstProtectionMilliseconds: 100, burstProtectionMax: 100});
+    const base = new Base("testing", {
+      burstProtectionMilliseconds: 100,
+      burstProtectionMax: 100,
+    });
 
     // Add a mock sync method
     base.setSync(async logs => logs);
@@ -470,7 +478,10 @@ describe("base class tests", () => {
   it("should limit sent requests if exceeding burst protection limits", async () => {
     // Fixtures
     const message = "Testing logging";
-    const base = new Base("testing", { burstProtectionMilliseconds: 100, burstProtectionMax: 50 });
+    const base = new Base("testing", {
+      burstProtectionMilliseconds: 100,
+      burstProtectionMax: 50,
+    });
 
     // Add a mock sync method
     base.setSync(async logs => logs);
@@ -483,7 +494,11 @@ describe("base class tests", () => {
     const logs = [];
     for (let i = 0; i < 500; i++) {
       // Send logs with 1ms delay between them
-      logs.push(new Promise(resolve => { setTimeout(() => base.info(message).then(resolve), i) }))
+      logs.push(
+        new Promise(resolve => {
+          setTimeout(() => base.info(message).then(resolve), i);
+        }),
+      );
     }
 
     await Promise.all(logs);
@@ -496,7 +511,9 @@ describe("base class tests", () => {
     expect(base.logged).toBeGreaterThan(240);
     expect(base.logged).toBeLessThan(260);
 
-    expect(mockedConsoleError).toHaveBeenCalledWith("Logging was called more than 50 times during last 100ms. Ignoring.");
+    expect(mockedConsoleError).toHaveBeenCalledWith(
+      "Logging was called more than 50 times during last 100ms. Ignoring.",
+    );
     expect(mockedConsoleError).toHaveBeenCalledTimes(5);
   });
 

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -5,7 +5,7 @@ import {
   Context,
   LogLevel,
   Middleware,
-  Sync
+  Sync,
 } from "@logtail/types";
 import { makeBatch, makeBurstProtection, makeThrottle } from "@logtail/tools";
 
@@ -103,10 +103,7 @@ class Logtail {
    * @param sourceToken: string - Private source token for logging to Logtail.com
    * @param options?: ILogtailOptions - Optionally specify Logtail options
    */
-  public constructor(
-    sourceToken: string,
-    options?: Partial<ILogtailOptions>
-  ) {
+  public constructor(sourceToken: string, options?: Partial<ILogtailOptions>) {
     // First, check we have a valid source token
     if (typeof sourceToken !== "string" || sourceToken === "") {
       throw new Error("Logtail source token missing");
@@ -128,18 +125,18 @@ class Logtail {
 
     // Burst protection for logging
     this._logBurstProtection = makeBurstProtection(
-        this._options.burstProtectionMilliseconds,
-        this._options.burstProtectionMax,
-        'Logging',
-    )
-    this.log = this._logBurstProtection(this.log.bind(this))
+      this._options.burstProtectionMilliseconds,
+      this._options.burstProtectionMax,
+      "Logging",
+    );
+    this.log = this._logBurstProtection(this.log.bind(this));
 
     // Create a batcher, for aggregating logs by buffer size/interval
     const batcher = makeBatch(
       this._options.batchSize,
       this._options.batchInterval,
       this._options.retryCount,
-      this._options.retryBackoff
+      this._options.retryBackoff,
     );
 
     this._batch = batcher.initPusher((logs: any) => {
@@ -152,7 +149,7 @@ class Logtail {
   /* PRIVATE METHODS */
   private getContextFromError(e: Error) {
     return {
-      stack: e.stack
+      stack: e.stack,
     };
   }
 
@@ -162,7 +159,7 @@ class Logtail {
    * Flush batched logs to Logtail
    */
   public async flush() {
-    return this._flush()
+    return this._flush();
   }
 
   /**
@@ -203,25 +200,25 @@ class Logtail {
   public async log<TContext extends Context>(
     message: Message,
     level: ILogLevel = LogLevel.Info,
-    context: TContext = {} as TContext
+    context: TContext = {} as TContext,
   ): Promise<ILogtailLog & TContext> {
     if (this._options.sendLogsToConsoleOutput) {
       switch (level) {
         case "debug":
-          console.debug(message, context)
-          break
+          console.debug(message, context);
+          break;
         case "info":
-          console.info(message, context)
-          break
+          console.info(message, context);
+          break;
         case "warn":
-          console.warn(message, context)
-          break
+          console.warn(message, context);
+          break;
         case "error":
-          console.error(message, context)
-          break
+          console.error(message, context);
+          break;
         default:
-          console.log(`[${level.toUpperCase()}]`, message, context)
-          break
+          console.log(`[${level.toUpperCase()}]`, message, context);
+          break;
       }
     }
 
@@ -242,7 +239,7 @@ class Logtail {
       level,
 
       // Add initial context
-      ...context
+      ...context,
     };
 
     // Determine the type of message...
@@ -257,7 +254,7 @@ class Logtail {
         ...this.getContextFromError(message),
 
         // Add error message
-        message: message.message
+        message: message.message,
       };
     } else {
       log = {
@@ -265,7 +262,7 @@ class Logtail {
         ...log,
 
         // Add string message
-        message
+        message,
       };
     }
 
@@ -319,7 +316,7 @@ class Logtail {
    */
   public async debug<TContext extends Context>(
     message: Message,
-    context: TContext = {} as TContext
+    context: TContext = {} as TContext,
   ) {
     return this.log(message, LogLevel.Debug, context);
   }
@@ -334,7 +331,7 @@ class Logtail {
    */
   public async info<TContext extends Context>(
     message: Message,
-    context: TContext = {} as TContext
+    context: TContext = {} as TContext,
   ) {
     return this.log(message, LogLevel.Info, context);
   }
@@ -349,7 +346,7 @@ class Logtail {
    */
   public async warn<TContext extends Context>(
     message: Message,
-    context: TContext = {} as TContext
+    context: TContext = {} as TContext,
   ) {
     return this.log(message, LogLevel.Warn, context);
   }
@@ -364,7 +361,7 @@ class Logtail {
    */
   public async error<TContext extends Context>(
     message: Message,
-    context: TContext = {} as TContext
+    context: TContext = {} as TContext,
   ) {
     return this.log(message, LogLevel.Error, context);
   }
@@ -402,7 +399,11 @@ class Logtail {
 
 // noinspection JSUnusedGlobalSymbols
 export default class extends Logtail {
-  async log<TContext extends Context>(message: Message, level: ILogLevel = LogLevel.Info, context: TContext = {} as TContext): Promise<ILogtailLog & TContext> {
+  async log<TContext extends Context>(
+    message: Message,
+    level: ILogLevel = LogLevel.Info,
+    context: TContext = {} as TContext,
+  ): Promise<ILogtailLog & TContext> {
     return super.log(message, level, context);
   }
-};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,5 +4,5 @@ export {
   /**
    * Classes
    */
-  Base
+  Base,
 };

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/koa)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/koa/src/koa.test.ts
+++ b/packages/koa/src/koa.test.ts
@@ -10,7 +10,7 @@ function getServer(): [KoaLogtail, Koa] {
   // Init new Koa Logtail instance
   const logtail = new KoaLogtail("test", {
     // Override `batchInterval` to test logs faster
-    batchInterval: 1
+    batchInterval: 1,
   });
 
   // Create a new Koa instance
@@ -177,7 +177,7 @@ describe("Koa Logtail tests", () => {
   it("should not log 'Info' logs when the level is 'Warn'", async done => {
     const [logtail, koa] = getServer();
 
-    logtail.setLevel(LogLevel.Warn)
+    logtail.setLevel(LogLevel.Warn);
 
     // Mock out the sync method
     logtail.setSync(async logs => {
@@ -185,7 +185,7 @@ describe("Koa Logtail tests", () => {
       expect(logs.length).toBe(1);
 
       // Should show an error
-      expect(logs[0].message).toContain('Koa HTTP request: 404');
+      expect(logs[0].message).toContain("Koa HTTP request: 404");
 
       // Should be 'warn' level
       expect(logs[0].level).toBe(LogLevel.Warn);
@@ -198,12 +198,12 @@ describe("Koa Logtail tests", () => {
 
     // This request should log "info", and thus not be logged.
     await request(koa.callback())
-        .get("/ping")
-        .expect(200);
+      .get("/ping")
+      .expect(200);
 
     // This request should log "warn", and thus be logged.
     await request(koa.callback())
-        .get("/throw")
-        .expect(404);
-  })
+      .get("/throw")
+      .expect(404);
+  });
 });

--- a/packages/koa/src/koa.ts
+++ b/packages/koa/src/koa.ts
@@ -42,14 +42,14 @@ const defaultKoaOpt: IKoaOptions = {
     "request.method",
     "request.length",
     "request.url",
-    "request.query"
+    "request.query",
   ],
   excludedRoutes: [],
   excludedMethods: [],
   level: LogLevel.Info,
   messageFormatter: ctx => `Koa HTTP request: ${ctx.status}`,
   errorMessageFormatter: (ctx, e) =>
-    `Koa HTTP request error: ${(typeof e === "object" && e.message) || e}`
+    `Koa HTTP request error: ${(typeof e === "object" && e.message) || e}`,
 };
 
 class KoaLogtail extends Logtail {
@@ -58,7 +58,7 @@ class KoaLogtail extends Logtail {
   public constructor(
     sourceToken: string,
     logtailOpt?: Partial<ILogtailOptions>,
-    koaOpt?: Partial<IKoaOptions>
+    koaOpt?: Partial<IKoaOptions>,
   ) {
     super(sourceToken, logtailOpt);
 
@@ -115,7 +115,8 @@ class KoaLogtail extends Logtail {
       if (
         !this._koaOptions.excludedMethods.includes(ctx.request.method) &&
         !this._koaOptions.excludedRoutes.includes(ctx.request.url) &&
-        this._toLevelNumber(logLevel) >= this._toLevelNumber(this._koaOptions.level)
+        this._toLevelNumber(logLevel) >=
+          this._toLevelNumber(this._koaOptions.level)
       ) {
         void this[logLevel](msg!, this._fromContext(ctx));
       }
@@ -152,7 +153,7 @@ class KoaLogtail extends Logtail {
    * Sets minimal log level to be logged.
    */
   public setLevel(level: LogLevel): this {
-    this._koaOptions.level = level
+    this._koaOptions.level = level;
     return this;
   }
 }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,4 +1,4 @@
-# [Better Stack](https://betterstack.com/logs) Node.js client 
+# [Better Stack](https://betterstack.com/logs) Node.js client
 
 📣 Logtail is now part of Better Stack. [Learn more ⇗](https://betterstack.com/press/introducing-better-stack/)
 
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -1,6 +1,6 @@
 import { Context, StackContextHint } from "@logtail/types";
 import { dirname, relative } from "path";
-import stackTrace, { StackFrame } from 'stack-trace';
+import stackTrace, { StackFrame } from "stack-trace";
 import { Node } from "./node";
 
 const mainFile = mainFileName();
@@ -10,7 +10,10 @@ const mainFile = mainFileName();
  *
  * @returns Context The caller's filename and the line number
  */
-export function getStackContext(logtail: Node, stackContextHint?: StackContextHint): Context {
+export function getStackContext(
+  logtail: Node,
+  stackContextHint?: StackContextHint,
+): Context {
   const stackFrame = getCallingFrame(logtail, stackContextHint);
   if (stackFrame === null) return {};
 
@@ -27,13 +30,22 @@ export function getStackContext(logtail: Node, stackContextHint?: StackContextHi
       system: {
         pid: process.pid,
         main_file: mainFile,
-      }
-    }
+      },
+    },
   };
 }
 
-function getCallingFrame(logtail: Node, stackContextHint?: StackContextHint): StackFrame | null {
-  for (let fn of [logtail.warn, logtail.error, logtail.info, logtail.debug, logtail.log]) {
+function getCallingFrame(
+  logtail: Node,
+  stackContextHint?: StackContextHint,
+): StackFrame | null {
+  for (let fn of [
+    logtail.warn,
+    logtail.error,
+    logtail.info,
+    logtail.debug,
+    logtail.log,
+  ]) {
     const stack = stackTrace.get(fn as any);
     if (stack.length > 0) return getRelevantStackFrame(stack, stackContextHint);
   }
@@ -41,11 +53,17 @@ function getCallingFrame(logtail: Node, stackContextHint?: StackContextHint): St
   return null;
 }
 
-function getRelevantStackFrame(frames: StackFrame[], stackContextHint?: StackContextHint): StackFrame {
+function getRelevantStackFrame(
+  frames: StackFrame[],
+  stackContextHint?: StackContextHint,
+): StackFrame {
   if (stackContextHint) {
     let reversedFrames = frames.reverse();
-    let index = reversedFrames.findIndex((frame) => {
-      return frame.getFileName()?.includes(stackContextHint.fileName) && stackContextHint.methodNames.includes(frame.getMethodName())
+    let index = reversedFrames.findIndex(frame => {
+      return (
+        frame.getFileName()?.includes(stackContextHint.fileName) &&
+        stackContextHint.methodNames.includes(frame.getMethodName())
+      );
     });
 
     if (index > 0) return reversedFrames[index - 1];
@@ -55,7 +73,7 @@ function getRelevantStackFrame(frames: StackFrame[], stackContextHint?: StackCon
 }
 
 function relativeToMainModule(fileName: string): string | null {
-  if (typeof(fileName) !== "string") {
+  if (typeof fileName !== "string") {
     return null;
   } else if (fileName.startsWith("file:/")) {
     const url = new URL(fileName);
@@ -68,16 +86,16 @@ function relativeToMainModule(fileName: string): string | null {
 
 function mainFileName(): string {
   let argv = process?.argv;
-  if (argv === undefined) return '';
+  if (argv === undefined) return "";
   // return first js file argument - arg ending in .js
   for (const arg of argv) {
-    if (typeof(arg) !== "string" || arg.startsWith('-')) {
+    if (typeof arg !== "string" || arg.startsWith("-")) {
       // break on first option
       break;
     }
-    if (arg.endsWith('.js')) {
+    if (arg.endsWith(".js")) {
       return arg;
     }
   }
-  return '';
+  return "";
 }

--- a/packages/node/src/node.test.ts
+++ b/packages/node/src/node.test.ts
@@ -15,14 +15,14 @@ function getRandomLog(message: string): Partial<ILogtailLog> {
   return {
     dt: new Date(),
     level: LogLevel.Info,
-    message
+    message,
   };
 }
 
 describe("node tests", () => {
   it("should echo log if logtail sends 20x status code", async () => {
     nock("https://in.logtail.com")
-      .post('/')
+      .post("/")
       .reply(201);
 
     const message: string = String(Math.random());
@@ -34,18 +34,21 @@ describe("node tests", () => {
 
   it("should throw error if logtail sends non 200 status code", async () => {
     nock("https://in.logtail.com")
-      .post('/')
+      .post("/")
       .reply(401);
 
-    const node = new Node("invalid source token", { ignoreExceptions: false, throwExceptions: true });
+    const node = new Node("invalid source token", {
+      ignoreExceptions: false,
+      throwExceptions: true,
+    });
     const message: string = String(Math.random);
     await expect(node.log(message)).rejects.toThrow();
   });
 
   it("should warn and echo log even with circular reference as context", async () => {
     nock("https://in.logtail.com")
-        .post('/')
-        .reply(201);
+      .post("/")
+      .reply(201);
 
     let circularContext: any = { foo: { value: 42 } };
     circularContext.foo.bar = circularContext;
@@ -63,7 +66,7 @@ describe("node tests", () => {
       write(
         chunk: any,
         encoding: string,
-        callback: (error?: Error | null) => void
+        callback: (error?: Error | null) => void,
       ): void {
         // Will be a buffered JSON string -- parse
         const log: ILogtailLog = JSON.parse(chunk.toString());
@@ -72,7 +75,7 @@ describe("node tests", () => {
         expect(log.message).toEqual(message);
 
         callback();
-      }
+      },
     });
 
     // Fixtures

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,12 +1,19 @@
-import {Duplex, Writable} from "stream";
+import { Duplex, Writable } from "stream";
 
 import fetch from "cross-fetch";
-import {encode} from "@msgpack/msgpack";
+import { encode } from "@msgpack/msgpack";
 
-import {Context, ILogLevel, ILogtailLog, ILogtailOptions, LogLevel, StackContextHint} from "@logtail/types";
-import {Base} from "@logtail/core";
+import {
+  Context,
+  ILogLevel,
+  ILogtailLog,
+  ILogtailOptions,
+  LogLevel,
+  StackContextHint,
+} from "@logtail/types";
+import { Base } from "@logtail/core";
 
-import {getStackContext} from "./context";
+import { getStackContext } from "./context";
 
 export class Node extends Base {
   /**
@@ -15,26 +22,20 @@ export class Node extends Base {
    */
   private _writeStream?: Writable | Duplex;
 
-  public constructor(
-    sourceToken: string,
-    options?: Partial<ILogtailOptions>
-  ) {
+  public constructor(sourceToken: string, options?: Partial<ILogtailOptions>) {
     super(sourceToken, options);
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
-      const res = await fetch(
-        this._options.endpoint,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/msgpack",
-            Authorization: `Bearer ${this._sourceToken}`,
-            "User-Agent": "logtail-js(node)"
-          },
-          body: this.encodeAsMsgpack(logs)
-        }
-      );
+      const res = await fetch(this._options.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/msgpack",
+          Authorization: `Bearer ${this._sourceToken}`,
+          "User-Agent": "logtail-js(node)",
+        },
+        body: this.encodeAsMsgpack(logs),
+      });
 
       if (res.ok) {
         return logs;
@@ -59,10 +60,10 @@ export class Node extends Base {
     message: string,
     level?: ILogLevel,
     context: TContext = {} as TContext,
-    stackContextHint?: StackContextHint
+    stackContextHint?: StackContextHint,
   ) {
     // Wrap context in an object, if it's not already
-    if (typeof context !== 'object') {
+    if (typeof context !== "object") {
       const wrappedContext: unknown = { extra: context };
       context = wrappedContext as TContext;
     }
@@ -96,14 +97,30 @@ export class Node extends Base {
 
   private encodeAsMsgpack(logs: ILogtailLog[]): Buffer {
     const maxDepth = this._options.contextObjectMaxDepth;
-    const logsWithISODateFormat = logs.map((log) => ({ ...this.sanitizeForEncoding(log, maxDepth), dt: log.dt.toISOString() }));
+    const logsWithISODateFormat = logs.map(log => ({
+      ...this.sanitizeForEncoding(log, maxDepth),
+      dt: log.dt.toISOString(),
+    }));
     const encoded = encode(logsWithISODateFormat);
-    const buffer = Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength)
+    const buffer = Buffer.from(
+      encoded.buffer,
+      encoded.byteOffset,
+      encoded.byteLength,
+    );
     return buffer;
   }
 
-  private sanitizeForEncoding(value: any, maxDepth: number, visitedObjects: WeakSet<any> = new WeakSet()): any {
-    if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+  private sanitizeForEncoding(
+    value: any,
+    maxDepth: number,
+    visitedObjects: WeakSet<any> = new WeakSet(),
+  ): any {
+    if (
+      value === null ||
+      typeof value === "boolean" ||
+      typeof value === "number" ||
+      typeof value === "string"
+    ) {
       return value;
     } else if (value instanceof Date) {
       // Date instances can be invalid & toISOString() will fail
@@ -118,23 +135,32 @@ export class Node extends Base {
         message: value.message,
         stack: value.stack?.split("\n"),
       };
-    } else if ((typeof value === "object" || Array.isArray(value)) && (maxDepth < 1 || visitedObjects.has(value))) {
+    } else if (
+      (typeof value === "object" || Array.isArray(value)) &&
+      (maxDepth < 1 || visitedObjects.has(value))
+    ) {
       if (visitedObjects.has(value)) {
         if (this._options.contextObjectCircularRefWarn) {
-          console.warn(`[Logtail] Found a circular reference when serializing logs. Please do not use circular references in your logs.`);
+          console.warn(
+            `[Logtail] Found a circular reference when serializing logs. Please do not use circular references in your logs.`,
+          );
         }
-        return '<omitted circular reference>'
+        return "<omitted circular reference>";
       }
       if (this._options.contextObjectMaxDepthWarn) {
-        console.warn(`[Logtail] Max depth of ${this._options.contextObjectMaxDepth} reached when serializing logs. Please do not use excessive object depth in your logs.`);
+        console.warn(
+          `[Logtail] Max depth of ${this._options.contextObjectMaxDepth} reached when serializing logs. Please do not use excessive object depth in your logs.`,
+        );
       }
-      return `<omitted context beyond configured max depth: ${this._options.contextObjectMaxDepth}>`
+      return `<omitted context beyond configured max depth: ${this._options.contextObjectMaxDepth}>`;
     } else if (Array.isArray(value)) {
       visitedObjects.add(value);
-      const sanitizedArray = value.map((item) => this.sanitizeForEncoding(item, maxDepth-1, visitedObjects));
+      const sanitizedArray = value.map(item =>
+        this.sanitizeForEncoding(item, maxDepth - 1, visitedObjects),
+      );
       visitedObjects.delete(value);
 
-      return sanitizedArray
+      return sanitizedArray;
     } else if (typeof value === "object") {
       const logClone: { [key: string]: any } = {};
 
@@ -144,8 +170,12 @@ export class Node extends Base {
         const key = item[0];
         const value = item[1];
 
-        const result = this.sanitizeForEncoding(value, maxDepth-1, visitedObjects);
-        if (result !== undefined){
+        const result = this.sanitizeForEncoding(
+          value,
+          maxDepth - 1,
+          visitedObjects,
+        );
+        if (result !== undefined) {
           logClone[key] = result;
         }
       });
@@ -153,7 +183,7 @@ export class Node extends Base {
       visitedObjects.delete(value);
 
       return logClone;
-    } else if (typeof value === 'undefined') {
+    } else if (typeof value === "undefined") {
       return undefined;
     } else {
       return `<omitted unserializable ${typeof value}>`;

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/pino)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -1,4 +1,3 @@
 import { logtailTransport } from "./pino";
 
-export default logtailTransport
-
+export default logtailTransport;

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -7,7 +7,6 @@
 **Looking for a logging solution?**  
 Check out [Better Stack](https://betterstack.com/logs) and [Better Stack clients for JavaScript and Node.js](https://betterstack.com/docs/logs/javascript/).
 
-
 ## `@logtail/tools`
 
 This library provides helper tools used by the [JavaScript logger](https://github.com/logtail/logtail-js).
@@ -67,8 +66,8 @@ const logtail = new Logtail("sourceToken");
 const throttle = makeThrottle(2);
 
 // Create a basic pipeline function which resolves after 2 seconds
-const pipeline = async (log) =>
-  new Promise((resolve) => {
+const pipeline = async log =>
+  new Promise(resolve => {
     setTimeout(() => resolve(log), 2000);
   });
 

--- a/packages/tools/src/batch.test.ts
+++ b/packages/tools/src/batch.test.ts
@@ -11,7 +11,7 @@ function getRandomLog(): ILogtailLog {
   return {
     dt: new Date(),
     level: LogLevel.Info,
-    message: String(Math.random())
+    message: String(Math.random()),
   };
 }
 
@@ -76,7 +76,7 @@ describe("batch tests", () => {
       throw err;
     });
 
-    await Promise.all(logNumberTimes(logger, 5)).catch(e => {})
+    await Promise.all(logNumberTimes(logger, 5)).catch(e => {});
     expect(called).toHaveBeenCalledTimes(4); // 3 retries + 1 initial
     done();
   });
@@ -91,12 +91,12 @@ describe("batch tests", () => {
 
     const batcher = makeBatch(size, sendTimeout, retryCount, retryBackoff);
     const logger = batcher.initPusher(async (batch: ILogtailLog[]) => {
-      called()
-      throw err
+      called();
+      throw err;
     });
 
-    logger(getRandomLog()).catch(e => {})
-    await batcher.flush()
+    logger(getRandomLog()).catch(e => {});
+    await batcher.flush();
 
     expect(called).toHaveBeenCalledTimes(4); // 3 retries + 1 initial
     done();
@@ -154,8 +154,8 @@ describe("batch tests", () => {
 
   it("should send after flush (with long timeout)", async done => {
     nock("http://example.com")
-        .get("/")
-        .reply(200, new Promise(res => setTimeout(() => res(200), 1003)));
+      .get("/")
+      .reply(200, new Promise(res => setTimeout(() => res(200), 1003)));
 
     const called = jest.fn();
     const size = 50;
@@ -171,10 +171,10 @@ describe("batch tests", () => {
       }
     });
 
-    logNumberTimes(logger, 5)
+    logNumberTimes(logger, 5);
     expect(called).toHaveBeenCalledTimes(0);
     try {
-      await batcher.flush()
+      await batcher.flush();
     } catch (e) {
       throw e;
     }

--- a/packages/tools/src/batch.ts
+++ b/packages/tools/src/batch.ts
@@ -43,7 +43,7 @@ export default function makeBatch(
   size: number = DEFAULT_BUFFER_SIZE,
   flushTimeout: number = DEFAULT_FLUSH_TIMEOUT,
   retryCount: number = DEFAULT_RETRY_COUNT,
-  retryBackoff: number = DEFAULT_RETRY_BACKOFF
+  retryBackoff: number = DEFAULT_RETRY_BACKOFF,
 ) {
   let timeout: NodeJS.Timeout | null;
   let cb: Function;
@@ -85,15 +85,15 @@ export default function makeBatch(
    */
   async function setupTimeout() {
     if (timeout) {
-      return
+      return;
     }
 
     return new Promise<void>(resolve => {
-      timeout = setTimeout(async function () {
-        await flush()
-        resolve()
-      }, flushTimeout)
-    })
+      timeout = setTimeout(async function() {
+        await flush();
+        resolve();
+      }, flushTimeout);
+    });
   }
 
   /*
@@ -101,16 +101,16 @@ export default function makeBatch(
    * @param fn - Any function to process list
    */
   return {
-    initPusher: function (fn: Function) {
+    initPusher: function(fn: Function) {
       cb = fn;
 
       /*
        * Pushes each log into list
        * @param log: ILogtailLog - Any object to push into list
        */
-      return async function (log: ILogtailLog): Promise<ILogtailLog> {
+      return async function(log: ILogtailLog): Promise<ILogtailLog> {
         return new Promise<ILogtailLog>(async (resolve, reject) => {
-          buffer.push({log, resolve, reject});
+          buffer.push({ log, resolve, reject });
 
           // If the buffer is full enough, flush it
           // Unless we're still waiting for the minimum retry backoff time
@@ -124,6 +124,6 @@ export default function makeBatch(
         });
       };
     },
-    flush
+    flush,
   };
 }

--- a/packages/tools/src/burstProtection.ts
+++ b/packages/tools/src/burstProtection.ts
@@ -11,10 +11,10 @@ const RESOLUTION = 64;
 export default function makeBurstProtection<T extends (...args: any[]) => any>(
   milliseconds: number,
   max: number,
-  functionName: string = 'The function',
+  functionName: string = "The function",
 ) {
   if (milliseconds <= 0 || max <= 0) {
-    return (fn: T) => fn
+    return (fn: T) => fn;
   }
 
   let callCounts: number[] = [0];
@@ -22,17 +22,22 @@ export default function makeBurstProtection<T extends (...args: any[]) => any>(
   let lastIntervalTime: number = Date.now();
 
   function updateCallCounts() {
-    const now = Date.now()
-    const intervalLength = milliseconds / RESOLUTION
+    const now = Date.now();
+    const intervalLength = milliseconds / RESOLUTION;
 
     if (now < lastIntervalTime + intervalLength) {
-      return
+      return;
     }
 
     // Prepend callCounts with correct number of zeroes and keep its length to RESOLUTION at max
-    const intervalCountSinceLast = Math.floor((now - lastIntervalTime) / intervalLength)
-    callCounts = Array(Math.min(intervalCountSinceLast, RESOLUTION)).fill(0).concat(callCounts).slice(0, RESOLUTION)
-    lastIntervalTime += intervalCountSinceLast * intervalLength
+    const intervalCountSinceLast = Math.floor(
+      (now - lastIntervalTime) / intervalLength,
+    );
+    callCounts = Array(Math.min(intervalCountSinceLast, RESOLUTION))
+      .fill(0)
+      .concat(callCounts)
+      .slice(0, RESOLUTION);
+    lastIntervalTime += intervalCountSinceLast * intervalLength;
   }
 
   function getTotalCallCount() {
@@ -40,21 +45,23 @@ export default function makeBurstProtection<T extends (...args: any[]) => any>(
   }
 
   function incrementCallCount() {
-    callCounts[0]++
+    callCounts[0]++;
   }
 
   return (fn: T) => {
     return async (...args: InferArgs<T>[]) => {
-      updateCallCounts()
+      updateCallCounts();
       if (getTotalCallCount() < max) {
         incrementCallCount();
-        return await fn(...args)
+        return await fn(...args);
       }
 
-      const now = Date.now()
+      const now = Date.now();
       if (lastErrorOutput < now - milliseconds) {
-        lastErrorOutput = now
-        console.error(`${functionName} was called more than ${max} times during last ${milliseconds}ms. Ignoring.`)
+        lastErrorOutput = now;
+        console.error(
+          `${functionName} was called more than ${max} times during last ${milliseconds}ms. Ignoring.`,
+        );
       }
     };
   };

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -14,5 +14,5 @@ export {
   base64Encode,
   makeBatch,
   makeBurstProtection,
-  makeThrottle
+  makeThrottle,
 };

--- a/packages/tools/src/retry.test.ts
+++ b/packages/tools/src/retry.test.ts
@@ -10,7 +10,7 @@ function getRandomLog(): ILogtailLog {
   return {
     dt: new Date(),
     level: LogLevel.Info,
-    message: String(Math.random())
+    message: String(Math.random()),
   };
 }
 

--- a/packages/tools/src/retry.ts
+++ b/packages/tools/src/retry.ts
@@ -11,7 +11,7 @@ let MAX_TRIES = 3;
  * @param sec - Number
  */
 function delay(sec: number): Promise<any> {
-  return new Promise((resolve) => setTimeout(resolve, sec * 1000));
+  return new Promise(resolve => setTimeout(resolve, sec * 1000));
 }
 
 /**
@@ -20,7 +20,7 @@ function delay(sec: number): Promise<any> {
  * @param fn - (logs: ILogtailLog[]) => Promise<ILogtailLog[]>
  */
 export default async function makeRetry(
-  fn: (logs: ILogtailLog[]) => Promise<ILogtailLog[]>
+  fn: (logs: ILogtailLog[]) => Promise<ILogtailLog[]>,
 ) {
   /**
    * number of retries

--- a/packages/tools/src/throttle.test.ts
+++ b/packages/tools/src/throttle.test.ts
@@ -25,7 +25,7 @@ describe("Throttle tests", () => {
           setTimeout(() => {
             resolve(log);
           }, throttleTime);
-        })
+        }),
     );
 
     // Build the promises

--- a/packages/tools/src/throttle.ts
+++ b/packages/tools/src/throttle.ts
@@ -6,7 +6,7 @@ import { InferArgs } from "./types";
  * @param max - maximum number of async functions to run
  */
 export default function makeThrottle<T extends (...args: any[]) => any>(
-  max: number
+  max: number,
 ) {
   // Current iteration cycle
   let current = 0;

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -134,7 +134,7 @@ We call this 'context' and these are the types:
  * Context type - a nested object of serializable types (a string / number / bool / null / undefined / Array / Date / Error)
  */
 export type ContextKey = any;
-export type Context = { [key: string]: ContextKey  };
+export type Context = { [key: string]: ContextKey };
 ```
 
 ### `ILogtailLog`

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -102,7 +102,7 @@ export enum LogLevel {
  */
 export type ContextKey = any;
 export type Context = { [key: string]: ContextKey };
-export type StackContextHint = { fileName: string, methodNames: [string] };
+export type StackContextHint = { fileName: string; methodNames: [string] };
 
 /**
  * Interface representing a minimal Logtail log

--- a/packages/winston/README.md
+++ b/packages/winston/README.md
@@ -14,6 +14,7 @@ Experience SQL-compatible structured log management based on ClickHouse. [Learn 
 [Getting started ⇗](https://betterstack.com/docs/logs/javascript/winston)
 
 ## Need help?
+
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!
 
 ---

--- a/packages/winston/src/winston.test.ts
+++ b/packages/winston/src/winston.test.ts
@@ -1,6 +1,6 @@
 import winston, { LogEntry } from "winston";
 import { Logtail } from "@logtail/node";
-import {LogLevel, ILogtailLog, Context} from "@logtail/types";
+import { LogLevel, ILogtailLog, Context } from "@logtail/types";
 
 import { LogtailTransport } from "./winston";
 
@@ -13,11 +13,15 @@ const message = "Something to do with something";
  * @param logLevel LogLevel - Logtail log level
  * @param levels Use custom log levels
  */
-async function testLevel(level: string, logLevel: LogLevel, levels?: {[key:string]: number}) {
+async function testLevel(
+  level: string,
+  logLevel: LogLevel,
+  levels?: { [key: string]: number },
+) {
   // Sample log
   const log: LogEntry = {
     level,
-    message
+    message,
   };
 
   // Logtail fixtures
@@ -53,13 +57,13 @@ async function testLevel(level: string, logLevel: LogLevel, levels?: {[key:strin
 }
 
 describe("Winston logging tests", () => {
-  const levels: { [key:string]: LogLevel } = {
-    "silly": LogLevel.Silly,
-    "debug": LogLevel.Debug,
-    "http": LogLevel.Http,
-    "verbose": LogLevel.Verbose,
-    "warn": LogLevel.Warn,
-    "error": LogLevel.Error,
+  const levels: { [key: string]: LogLevel } = {
+    silly: LogLevel.Silly,
+    debug: LogLevel.Debug,
+    http: LogLevel.Http,
+    verbose: LogLevel.Verbose,
+    warn: LogLevel.Warn,
+    error: LogLevel.Error,
   };
   for (const key in levels) {
     it(`should log at the '${key}' level`, async () => {
@@ -72,26 +76,26 @@ describe("Winston logging tests", () => {
     const entries: LogEntry[] = [
       {
         level: "info",
-        message: `${message} 1`
+        message: `${message} 1`,
       },
       {
         level: "debug",
-        message: `${message} 2`
+        message: `${message} 2`,
       },
       {
         level: "warn",
-        message: `${message} 3`
+        message: `${message} 3`,
       },
       {
         level: "error",
-        message: `${message} 4`
-      }
+        message: `${message} 4`,
+      },
     ];
 
     // Fixtures
     const logtail = new Logtail("test", {
       batchInterval: 1000, // <-- shouldn't be exceeded
-      batchSize: entries.length
+      batchSize: entries.length,
     });
 
     logtail.setSync(async logs => {
@@ -102,7 +106,7 @@ describe("Winston logging tests", () => {
         log =>
           entries.findIndex(entry => {
             return entry.message == log.message;
-          }) > -1
+          }) > -1,
       );
       expect(isIdentical).toBe(true);
 
@@ -115,7 +119,7 @@ describe("Winston logging tests", () => {
     // Create a Winston logger
     const logger = winston.createLogger({
       level: "debug", // <-- debug and above
-      transports: [new LogtailTransport(logtail)]
+      transports: [new LogtailTransport(logtail)],
     });
 
     entries.forEach(entry => logger.log(entry.level, entry.message));
@@ -133,7 +137,7 @@ describe("Winston logging tests", () => {
     // Create a Winston logger
     const logger = winston.createLogger({
       level: LogLevel.Info,
-      transports: [new LogtailTransport(logtail)]
+      transports: [new LogtailTransport(logtail)],
     });
 
     // Log it!
@@ -167,8 +171,8 @@ describe("Winston logging tests", () => {
       level: LogLevel.Info,
       transports: [new LogtailTransport(logtail)],
       defaultMeta: {
-        component: "server"
-      }
+        component: "server",
+      },
     });
 
     // Log it!
@@ -203,8 +207,8 @@ describe("Winston logging tests", () => {
       level: LogLevel.Info,
       transports: [new LogtailTransport(logtail)],
       defaultMeta: {
-        component: "server"
-      }
+        component: "server",
+      },
     });
 
     logger.info("message with context");

--- a/packages/winston/src/winston.ts
+++ b/packages/winston/src/winston.ts
@@ -2,12 +2,27 @@ import { LogEntry } from "winston";
 import Transport from "winston-transport";
 
 import { Logtail } from "@logtail/node";
-import {LogLevel, StackContextHint} from "@logtail/types";
+import { LogLevel, StackContextHint } from "@logtail/types";
 
-const stackContextHint = { fileName: "node_modules/winston", methodNames: [ "log", "error", "warn", "info", "http", "verbose", "debug", "silly" ] };
+const stackContextHint = {
+  fileName: "node_modules/winston",
+  methodNames: [
+    "log",
+    "error",
+    "warn",
+    "info",
+    "http",
+    "verbose",
+    "debug",
+    "silly",
+  ],
+};
 
 export class LogtailTransport extends Transport {
-  public constructor(private _logtail: Logtail, opts?: Transport.TransportStreamOptions) {
+  public constructor(
+    private _logtail: Logtail,
+    opts?: Transport.TransportStreamOptions,
+  ) {
     super(opts);
   }
 
@@ -22,7 +37,12 @@ export class LogtailTransport extends Transport {
     // Determine the log level
 
     // Log out to Logtail
-    void this._logtail.log(message, level, meta, stackContextHint as StackContextHint);
+    void this._logtail.log(
+      message,
+      level,
+      meta,
+      stackContextHint as StackContextHint,
+    );
 
     // Winston callback...
     cb();


### PR DESCRIPTION
Since I was working with CI and package.json, I've noticed we have a command `yarn lint` and `yarn lint:save` but don't really use them a coding standards are getting all over the place.

What do you think? If you don't like that, feel free to close the issue 🙂  I have no strong opinions, really.