### PR TITLE
Improve tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,20 @@ module.exports = {
       moduleFileExtensions: ["ts", "js"],
       testEnvironment: "node",
       testMatch: ["<rootDir>/packages/**/*.test.ts"],
-      testPathIgnorePatterns: ["/node_modules/", "/dist/", "/packages/edge/"],
+      testPathIgnorePatterns: ["/node_modules/", "/dist/", "/packages/browser/", "/packages/edge/"],
+      transform: {
+        "^.+\\.ts$": ["ts-jest", "tsconfig.json"]
+      },
+    },
+    {
+      displayName: 'Browser',
+      coverageDirectory: "coverage",
+      coveragePathIgnorePatterns: ["node_modules/", "dist/"],
+      moduleDirectories: ["node_modules"],
+      moduleFileExtensions: ["ts", "js"],
+      testEnvironment: "jsdom",
+      testMatch: ["<rootDir>/packages/browser/**/*.test.ts"],
+      testPathIgnorePatterns: ["/node_modules/", "/dist/"],
       transform: {
         "^.+\\.ts$": ["ts-jest", "tsconfig.json"]
       },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/jest": "^29.5.4",
     "@types/node": "^12.7.2",
     "jest": "^29.6.4",
+    "jest-environment-jsdom": "^29.7.0",
     "lerna": "^3.16.4",
     "prettier": "^1.18.2",
     "ts-jest": "^29.1.1",

--- a/packages/browser/src/browser.test.ts
+++ b/packages/browser/src/browser.test.ts
@@ -17,6 +17,14 @@ function getRandomLog(message: string): Partial<ILogtailLog> {
 (global as any).btoa = base64Encode;
 
 describe("browser tests", () => {
+  beforeEach(() => {
+    nock.restore();
+    nock.activate();
+  });
+  afterEach(() => {
+    nock.restore();
+  });
+
   // Awaiting: https://bugs.chromium.org/p/chromium/issues/detail?id=571722
 
   // it("should set a User-Agent based on the right version number", () => {
@@ -32,7 +40,9 @@ describe("browser tests", () => {
 
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
-    const browser = new Browser("valid source token");
+    const browser = new Browser("valid source token", {
+      throwExceptions: true,
+    });
     const echoedLog = await browser.log(message);
     expect(echoedLog.message).toEqual(expectedLog.message);
   });
@@ -43,7 +53,6 @@ describe("browser tests", () => {
       .reply(401);
 
     const browser = new Browser("invalid source token", {
-      ignoreExceptions: false,
       throwExceptions: true,
     });
     const message: string = String(Math.random);

--- a/packages/browser/yarn.lock
+++ b/packages/browser/yarn.lock
@@ -86,18 +86,18 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/bunyan/src/bunyan.test.ts
+++ b/packages/bunyan/src/bunyan.test.ts
@@ -35,7 +35,10 @@ function createLogger(logtail: Logtail): bunyan {
  */
 async function testLevel(level: LogLevelString, logLevel: LogLevel) {
   // Logtail fixtures
-  const logtail = new Logtail("test", { batchInterval: 1 });
+  const logtail = new Logtail("test", {
+    throwExceptions: true,
+    batchInterval: 1,
+  });
   logtail.setSync(async logs => {
     // Should be exactly one log
     expect(logs.length).toBe(1);
@@ -88,6 +91,7 @@ describe("Bunyan tests", () => {
     ];
 
     const logtail = new Logtail("test", {
+      throwExceptions: true,
       batchInterval: 1000,
       batchSize: levels.length,
     });
@@ -106,7 +110,7 @@ describe("Bunyan tests", () => {
   });
 
   it("should include arbitrary extra data fields", async () => {
-    const logtail = new Logtail("test");
+    const logtail = new Logtail("test", { throwExceptions: true });
     logtail.setSync(async logs => {
       expect(logs).toHaveLength(1);
       expect(logs[0].message).toEqual("i am the message");
@@ -120,7 +124,7 @@ describe("Bunyan tests", () => {
   });
 
   it("should include correct context fields", async () => {
-    const logtail = new Logtail("test");
+    const logtail = new Logtail("test", { throwExceptions: true });
     logtail.setSync(async logs => {
       const context = logs[0].context;
       expect(context.runtime.file).toMatch("bunyan.test.ts");

--- a/packages/bunyan/yarn.lock
+++ b/packages/bunyan/yarn.lock
@@ -26,20 +26,20 @@
     "@babel/helper-validator-identifier" "^7.22.15"
     to-fast-properties "^2.0.0"
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/node@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.9.tgz#83c4d7c094730ca6bc5f70b10b5faa1bee0ab6af"
-  integrity sha512-Gr4Oz6NEwYC8MWrw+YZx55s1p+LkAeEjQfiHY2BkfKiJz9k7O2ScFs+eqKdAOSINTYUC6HoUYfOTOqqWW8BzIg==
+"@logtail/node@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.10.tgz#f4d0c26a7e5e31fb964abace9aec5bc47b6232dd"
+  integrity sha512-+lM0JrEb75Rkx0ATrp1woffKtBdUCem1yNEYs8iEsA6c517byxL3pqVuRcoEleBBBIkrNd9EdaHfWY/ohKA6qw==
   dependencies:
-    "@logtail/core" "^0.4.9"
+    "@logtail/core" "^0.4.10"
     "@logtail/types" "^0.4.9"
     "@msgpack/msgpack" "^2.5.1"
     "@types/stack-trace" "^0.0.29"
@@ -47,10 +47,10 @@
     minimatch "^3.0.4"
     stack-trace "^0.0.10"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/core/src/base.test.ts
+++ b/packages/core/src/base.test.ts
@@ -4,13 +4,13 @@ import { ILogtailLog, LogLevel } from "@logtail/types";
 describe("base class tests", () => {
   it("should initialize with source token", () => {
     const sourceToken = "testing";
-    const base = new Base(sourceToken);
+    const base = new Base(sourceToken, { throwExceptions: true });
 
     expect((base as any)._sourceToken).toEqual(sourceToken);
   });
 
   it("should throw if a `sync` method is missing", async () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Expect logging to throw an error, since we're missing a `sync` func
     await expect(base.log("Test")).rejects.toThrowError(/sync/);
@@ -19,7 +19,7 @@ describe("base class tests", () => {
   it("should add an implicit `dt` timestamp", async () => {
     // Fixtures
     const message = "Test";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async logs => logs);
@@ -35,25 +35,25 @@ describe("base class tests", () => {
   });
 
   it("should default log count to zero", () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     expect(base.logged).toEqual(0);
   });
 
   it("should default synced count to zero", () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     expect(base.synced).toEqual(0);
   });
 
   it("should default dropped count to zero", () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     expect(base.dropped).toEqual(0);
   });
 
   it("should increment log count on `.log()`", async () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -65,7 +65,7 @@ describe("base class tests", () => {
   });
 
   it("should sync after 500 ms", async () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Create a sync function that resolves after 500ms
     base.setSync(async log => {
@@ -94,7 +94,11 @@ describe("base class tests", () => {
 
   it("should sync after calling flush", async () => {
     // New Base with very long batch interval and size
-    const base = new Base("testing", { batchInterval: 10000, batchSize: 5 });
+    const base = new Base("testing", {
+      throwExceptions: true,
+      batchInterval: 10000,
+      batchSize: 5,
+    });
 
     // Create a sync function that resolves after 50ms
     base.setSync(async log => {
@@ -124,7 +128,7 @@ describe("base class tests", () => {
   it("should add a pipeline function", async () => {
     // Fixtures
     const firstMessage = "First message";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -148,7 +152,7 @@ describe("base class tests", () => {
   });
 
   it("should remove a pipeline function", async () => {
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Create a pipeline function
     const customPipeline = async (log: ILogtailLog) => log;
@@ -169,7 +173,7 @@ describe("base class tests", () => {
   it("should default to 'info' level logging", async () => {
     // Fixtures
     const message = "Test";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -184,7 +188,7 @@ describe("base class tests", () => {
   it("should handle 'debug' logging", async () => {
     // Fixtures
     const message = "Test";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -199,7 +203,7 @@ describe("base class tests", () => {
   it("should handle 'info' logging", async () => {
     // Fixtures
     const message = "Test";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -214,7 +218,7 @@ describe("base class tests", () => {
   it("should handle 'warn' logging", async () => {
     // Fixtures
     const message = "Test";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -229,7 +233,7 @@ describe("base class tests", () => {
   it("should handle 'error' logging", async () => {
     // Fixtures
     const message = "Test";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -245,7 +249,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "This is the error";
     const e = new Error(message);
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method
     base.setSync(async log => log);
@@ -264,10 +268,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing exceptions";
     const e = new Error("Should NOT be ignored!");
-    const base = new Base("testing", {
-      ignoreExceptions: false,
-      throwExceptions: true,
-    });
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method which throws an error
     base.setSync(async () => {
@@ -280,9 +281,7 @@ describe("base class tests", () => {
   it("should ignore exceptions by default", async () => {
     // Fixtures
     const message = "Testing exceptions";
-    const base = new Base("testing", {
-      ignoreExceptions: true,
-    });
+    const base = new Base("testing", { ignoreExceptions: true });
 
     // Add a mock sync method which throws an error
     base.setSync(async () => {
@@ -299,7 +298,7 @@ describe("base class tests", () => {
   it("should sync all logs in single call", async () => {
     // Fixtures
     const message = "Testing logging";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method which counts sync calls and sent logs
     let syncCount = 0;
@@ -328,6 +327,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing logging";
     const base = new Base("testing", {
+      throwExceptions: true,
       sendLogsToBetterStack: false,
     });
 
@@ -358,6 +358,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing logging";
     const base = new Base("testing", {
+      throwExceptions: true,
       sendLogsToConsoleOutput: true,
       batchInterval: 10,
     });
@@ -408,7 +409,7 @@ describe("base class tests", () => {
   it("should limit sent requests", async () => {
     // Fixtures
     const message = "Testing logging";
-    const base = new Base("testing");
+    const base = new Base("testing", { throwExceptions: true });
 
     // Add a mock sync method which resolves after a timeout
     base.setSync(async logs => {
@@ -445,6 +446,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing logging";
     const base = new Base("testing", {
+      throwExceptions: true,
       burstProtectionMilliseconds: 100,
       burstProtectionMax: 100,
     });
@@ -479,6 +481,7 @@ describe("base class tests", () => {
     // Fixtures
     const message = "Testing logging";
     const base = new Base("testing", {
+      throwExceptions: true,
       burstProtectionMilliseconds: 100,
       burstProtectionMax: 50,
     });
@@ -520,7 +523,10 @@ describe("base class tests", () => {
   it("should not limit sent requests if burst protection disabled", async () => {
     // Fixtures
     const message = "Testing logging";
-    const base = new Base("testing", { burstProtectionMax: 0 });
+    const base = new Base("testing", {
+      throwExceptions: true,
+      burstProtectionMax: 0,
+    });
 
     // Add a mock sync method
     base.setSync(async logs => logs);

--- a/packages/core/yarn.lock
+++ b/packages/core/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/edge/src/edge.test.ts
+++ b/packages/edge/src/edge.test.ts
@@ -29,7 +29,7 @@ describe("edge tests", () => {
   it("should echo log if logtail sends 20x status code", async () => {
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
-    const edge = new Edge("valid source token");
+    const edge = new Edge("valid source token", { throwExceptions: true });
 
     edge.setSync(async logs => logs);
 
@@ -39,10 +39,7 @@ describe("edge tests", () => {
   });
 
   it("should throw error if logtail sends non 200 status code", async () => {
-    const edge = new Edge("invalid source token", {
-      ignoreExceptions: false,
-      throwExceptions: true,
-    });
+    const edge = new Edge("invalid source token", { throwExceptions: true });
 
     edge.setSync(async () => {
       throw new Error("Mocked error in logging");
@@ -59,7 +56,7 @@ describe("edge tests", () => {
 
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
-    const edge = new Edge("valid source token");
+    const edge = new Edge("valid source token", { throwExceptions: true });
 
     edge.setSync(async logs => logs);
 
@@ -70,7 +67,7 @@ describe("edge tests", () => {
 
   it("should contain context info", async () => {
     const message: string = String(Math.random());
-    const edge = new Edge("valid source token");
+    const edge = new Edge("valid source token", { throwExceptions: true });
 
     edge.setSync(async logs => logs);
 
@@ -84,7 +81,7 @@ describe("edge tests", () => {
 
   it("should warn about missing ExecutionContext only once", async () => {
     const message: string = String(Math.random());
-    const edge = new Edge("valid source token");
+    const edge = new Edge("valid source token", { throwExceptions: true });
 
     edge.setSync(async logs => logs);
 
@@ -102,7 +99,7 @@ describe("edge tests", () => {
 
   it("should not warn about missing ExecutionContext if set", async () => {
     const message: string = String(Math.random());
-    const edge = new Edge("valid source token");
+    const edge = new Edge("valid source token", { throwExceptions: true });
     edge.setSync(async logs => logs);
 
     const edgeWithCtx = edge.withExecutionContext({

--- a/packages/edge/src/edge.test.ts
+++ b/packages/edge/src/edge.test.ts
@@ -20,10 +20,15 @@ function getRandomLog(message: string): Partial<ILogtailLog> {
   };
 }
 
+const originalConsoleWarn = console.warn;
+
 describe("edge tests", () => {
   beforeEach(() => {
     // Mock console warnings
     console.warn = jest.fn();
+  });
+  afterEach(() => {
+    console.warn = originalConsoleWarn;
   });
 
   it("should echo log if logtail sends 20x status code", async () => {

--- a/packages/edge/yarn.lock
+++ b/packages/edge/yarn.lock
@@ -31,18 +31,18 @@
   resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-4.20230904.0.tgz#80e3b2384d7425c0b696a7aa8cab1b3c5d09e45c"
   integrity sha512-IX4oJCe14ctblSPZBlW64BVZ9nYLUo6sD2I5gu3hX0ywByYWm1OuoKm9Xb/Zpbj8Ph18Z7Ryii6u2/ocnncXdA==
 
-"@logtail/core@^0.4.6":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/js/yarn.lock
+++ b/packages/js/yarn.lock
@@ -2,29 +2,29 @@
 # yarn lockfile v1
 
 
-"@logtail/browser@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/browser/-/browser-0.4.9.tgz#5f80a9410d34161b7c9fc4da1f0a27f750a0b7c4"
-  integrity sha512-JmaFJtzWyQ1xUuEcN6+/XN+kAMUQPp4AGefDgjUQTdGKzI1jJPpm/dCeBANOU61s6eRMeQHQ5OyTlsnx+dVLig==
+"@logtail/browser@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/browser/-/browser-0.4.10.tgz#607c08f681d840bd84cc57a4411675d3e81593b1"
+  integrity sha512-YeUv6tJqgn4WM0zoq4XWcwNkYpuDKtHHdYLIS1TSZyeSdgBmKM9Bufej5o+fFvQtN1ai79jTEssFFkBiIGxm0g==
   dependencies:
-    "@logtail/core" "^0.4.9"
-    "@logtail/tools" "^0.4.9"
+    "@logtail/core" "^0.4.10"
+    "@logtail/tools" "^0.4.10"
     cross-fetch "^3.0.4"
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/node@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.9.tgz#83c4d7c094730ca6bc5f70b10b5faa1bee0ab6af"
-  integrity sha512-Gr4Oz6NEwYC8MWrw+YZx55s1p+LkAeEjQfiHY2BkfKiJz9k7O2ScFs+eqKdAOSINTYUC6HoUYfOTOqqWW8BzIg==
+"@logtail/node@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.10.tgz#f4d0c26a7e5e31fb964abace9aec5bc47b6232dd"
+  integrity sha512-+lM0JrEb75Rkx0ATrp1woffKtBdUCem1yNEYs8iEsA6c517byxL3pqVuRcoEleBBBIkrNd9EdaHfWY/ohKA6qw==
   dependencies:
-    "@logtail/core" "^0.4.9"
+    "@logtail/core" "^0.4.10"
     "@logtail/types" "^0.4.9"
     "@msgpack/msgpack" "^2.5.1"
     "@types/stack-trace" "^0.0.29"
@@ -32,10 +32,10 @@
     minimatch "^3.0.4"
     stack-trace "^0.0.10"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/koa/src/koa.test.ts
+++ b/packages/koa/src/koa.test.ts
@@ -9,6 +9,7 @@ import KoaLogtail from "./koa";
 function getServer(): [KoaLogtail, Koa] {
   // Init new Koa Logtail instance
   const logtail = new KoaLogtail("test", {
+    throwExceptions: true,
     // Override `batchInterval` to test logs faster
     batchInterval: 1,
   });

--- a/packages/koa/yarn.lock
+++ b/packages/koa/yarn.lock
@@ -26,20 +26,20 @@
     "@babel/helper-validator-identifier" "^7.22.15"
     to-fast-properties "^2.0.0"
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/node@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.9.tgz#83c4d7c094730ca6bc5f70b10b5faa1bee0ab6af"
-  integrity sha512-Gr4Oz6NEwYC8MWrw+YZx55s1p+LkAeEjQfiHY2BkfKiJz9k7O2ScFs+eqKdAOSINTYUC6HoUYfOTOqqWW8BzIg==
+"@logtail/node@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.10.tgz#f4d0c26a7e5e31fb964abace9aec5bc47b6232dd"
+  integrity sha512-+lM0JrEb75Rkx0ATrp1woffKtBdUCem1yNEYs8iEsA6c517byxL3pqVuRcoEleBBBIkrNd9EdaHfWY/ohKA6qw==
   dependencies:
-    "@logtail/core" "^0.4.9"
+    "@logtail/core" "^0.4.10"
     "@logtail/types" "^0.4.9"
     "@msgpack/msgpack" "^2.5.1"
     "@types/stack-trace" "^0.0.29"
@@ -47,10 +47,10 @@
     minimatch "^3.0.4"
     stack-trace "^0.0.10"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/node/src/node.test.ts
+++ b/packages/node/src/node.test.ts
@@ -7,6 +7,7 @@ import nock from "nock";
 import { ILogtailLog, LogLevel } from "@logtail/types";
 
 import { Node } from "./node";
+import { Mock } from "jest-mock";
 
 /**
  * Create a log with a random string / current date
@@ -50,11 +51,21 @@ describe("node tests", () => {
     let circularContext: any = { foo: { value: 42 } };
     circularContext.foo.bar = circularContext;
 
+    // Mock console warnings
+    const originalConsoleWarn = console.warn;
+    console.warn = jest.fn();
+
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
     const node = new Node("valid source token", { throwExceptions: true });
     const echoedLog = await node.log(message, LogLevel.Info, circularContext);
     expect(echoedLog.message).toEqual(expectedLog.message);
+
+    expect((console.warn as Mock).mock.calls).toHaveLength(1);
+    expect((console.warn as Mock).mock.calls[0][0]).toBe(
+      "[Logtail] Found a circular reference when serializing logs. Please do not use circular references in your logs.",
+    );
+    console.warn = originalConsoleWarn;
   });
 
   it("should enable piping logs to a writable stream", async () => {

--- a/packages/node/src/node.test.ts
+++ b/packages/node/src/node.test.ts
@@ -27,7 +27,7 @@ describe("node tests", () => {
 
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
-    const node = new Node("valid source token");
+    const node = new Node("valid source token", { throwExceptions: true });
     const echoedLog = await node.log(message);
     expect(echoedLog.message).toEqual(expectedLog.message);
   });
@@ -37,10 +37,7 @@ describe("node tests", () => {
       .post("/")
       .reply(401);
 
-    const node = new Node("invalid source token", {
-      ignoreExceptions: false,
-      throwExceptions: true,
-    });
+    const node = new Node("invalid source token", { throwExceptions: true });
     const message: string = String(Math.random);
     await expect(node.log(message)).rejects.toThrow();
   });
@@ -55,7 +52,7 @@ describe("node tests", () => {
 
     const message: string = String(Math.random());
     const expectedLog = getRandomLog(message);
-    const node = new Node("valid source token");
+    const node = new Node("valid source token", { throwExceptions: true });
     const echoedLog = await node.log(message, LogLevel.Info, circularContext);
     expect(echoedLog.message).toEqual(expectedLog.message);
   });
@@ -79,7 +76,7 @@ describe("node tests", () => {
     });
 
     // Fixtures
-    const logtail = new Node("test");
+    const logtail = new Node("test", { throwExceptions: true });
     logtail.pipe(writeStream);
 
     const message = "This should be streamed";
@@ -102,7 +99,7 @@ describe("node tests", () => {
     const passThrough = new PassThrough();
 
     // Pass write stream to Better Stack
-    const logtail = new Node("test");
+    const logtail = new Node("test", { throwExceptions: true });
     logtail.pipe(passThrough).pipe(writeStream);
 
     // Mock the sync method by simply returning the same logs

--- a/packages/node/yarn.lock
+++ b/packages/node/yarn.lock
@@ -26,18 +26,18 @@
     "@babel/helper-validator-identifier" "^7.22.15"
     to-fast-properties "^2.0.0"
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/pino/yarn.lock
+++ b/packages/pino/yarn.lock
@@ -2,20 +2,20 @@
 # yarn lockfile v1
 
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/node@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.9.tgz#83c4d7c094730ca6bc5f70b10b5faa1bee0ab6af"
-  integrity sha512-Gr4Oz6NEwYC8MWrw+YZx55s1p+LkAeEjQfiHY2BkfKiJz9k7O2ScFs+eqKdAOSINTYUC6HoUYfOTOqqWW8BzIg==
+"@logtail/node@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.10.tgz#f4d0c26a7e5e31fb964abace9aec5bc47b6232dd"
+  integrity sha512-+lM0JrEb75Rkx0ATrp1woffKtBdUCem1yNEYs8iEsA6c517byxL3pqVuRcoEleBBBIkrNd9EdaHfWY/ohKA6qw==
   dependencies:
-    "@logtail/core" "^0.4.9"
+    "@logtail/core" "^0.4.10"
     "@logtail/types" "^0.4.9"
     "@msgpack/msgpack" "^2.5.1"
     "@types/stack-trace" "^0.0.29"
@@ -23,10 +23,10 @@
     minimatch "^3.0.4"
     stack-trace "^0.0.10"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/packages/tools/src/batch.test.ts
+++ b/packages/tools/src/batch.test.ts
@@ -35,6 +35,14 @@ function calcEndTime(start: [number, number]): number {
 }
 
 describe("batch tests", () => {
+  beforeEach(() => {
+    nock.restore();
+    nock.activate();
+  });
+  afterEach(() => {
+    nock.restore();
+  });
+
   it("should not fire timeout while a send was happening.", async () => {
     nock("http://example.com")
       .get("/")
@@ -58,7 +66,6 @@ describe("batch tests", () => {
       throw e;
     });
     expect(called).toHaveBeenCalledTimes(1);
-    nock.restore();
   });
 
   it("should retry 3 times.", async () => {
@@ -176,6 +183,5 @@ describe("batch tests", () => {
       throw e;
     }
     expect(called).toHaveBeenCalledTimes(1);
-    nock.restore();
   });
 });

--- a/packages/winston/src/winston.test.ts
+++ b/packages/winston/src/winston.test.ts
@@ -25,7 +25,7 @@ async function testLevel(
   };
 
   // Logtail fixtures
-  const logtail = new Logtail("test");
+  const logtail = new Logtail("test", { throwExceptions: true });
   const logged = new Promise<ILogtailLog[]>(resolve => {
     logtail.setSync(async logs => {
       resolve(logs);
@@ -94,6 +94,7 @@ describe("Winston logging tests", () => {
 
     // Fixtures
     const logtail = new Logtail("test", {
+      throwExceptions: true,
       batchInterval: 1000, // <-- shouldn't be exceeded
       batchSize: entries.length,
     });
@@ -123,7 +124,7 @@ describe("Winston logging tests", () => {
   });
 
   it("should log metadata with the message and level", async () => {
-    const logtail = new Logtail("test");
+    const logtail = new Logtail("test", { throwExceptions: true });
     const logged = new Promise<ILogtailLog[]>(resolve => {
       logtail.setSync(async logs => {
         resolve(logs);
@@ -155,7 +156,7 @@ describe("Winston logging tests", () => {
   });
 
   it("should log defaultMetadata with the message and level", async () => {
-    const logtail = new Logtail("test");
+    const logtail = new Logtail("test", { throwExceptions: true });
     const logged = new Promise<ILogtailLog[]>(resolve => {
       logtail.setSync(async logs => {
         resolve(logs);
@@ -191,7 +192,7 @@ describe("Winston logging tests", () => {
   });
 
   it("should include correct context fields", async () => {
-    const logtail = new Logtail("test");
+    const logtail = new Logtail("test", { throwExceptions: true });
     const logged = new Promise<ILogtailLog[]>(resolve => {
       logtail.setSync(async logs => {
         resolve(logs);

--- a/packages/winston/yarn.lock
+++ b/packages/winston/yarn.lock
@@ -16,20 +16,20 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@logtail/core@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.9.tgz#78f2aeaacf02e6a34c93d859694341104d26e232"
-  integrity sha512-f9Dgt84OiLsn6lEzF7eCi9ND2ZPrY6jdmbDA55t0i5H5EfE7sehIgB6oof5YqPF9TB/p72sNoxKi5FDAb5iDrw==
+"@logtail/core@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/core/-/core-0.4.10.tgz#e2a5e273df82d4239890941ae79733af1a77e2ad"
+  integrity sha512-CBpZtuJ05kcV4z9Nb9l2o6JtuoAM2z0nt9ziReW4ozXJZFF73oKpSX4YThERWb0w2qh4Wor5kdupAjUvzAuukQ==
   dependencies:
-    "@logtail/tools" "^0.4.9"
+    "@logtail/tools" "^0.4.10"
     "@logtail/types" "^0.4.9"
 
-"@logtail/node@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.9.tgz#83c4d7c094730ca6bc5f70b10b5faa1bee0ab6af"
-  integrity sha512-Gr4Oz6NEwYC8MWrw+YZx55s1p+LkAeEjQfiHY2BkfKiJz9k7O2ScFs+eqKdAOSINTYUC6HoUYfOTOqqWW8BzIg==
+"@logtail/node@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/node/-/node-0.4.10.tgz#f4d0c26a7e5e31fb964abace9aec5bc47b6232dd"
+  integrity sha512-+lM0JrEb75Rkx0ATrp1woffKtBdUCem1yNEYs8iEsA6c517byxL3pqVuRcoEleBBBIkrNd9EdaHfWY/ohKA6qw==
   dependencies:
-    "@logtail/core" "^0.4.9"
+    "@logtail/core" "^0.4.10"
     "@logtail/types" "^0.4.9"
     "@msgpack/msgpack" "^2.5.1"
     "@types/stack-trace" "^0.0.29"
@@ -37,10 +37,10 @@
     minimatch "^3.0.4"
     stack-trace "^0.0.10"
 
-"@logtail/tools@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.9.tgz#c234ba144af68a8daae7b321b7239564918edea8"
-  integrity sha512-JfLG01JARLNmbCvrqGdQ7c7O1cVTNWLWgJ81+mQ/ZtlQVTJezVH+uQHwa2Qcez1vKOYOlgbL0s1/xJm0QJPKHQ==
+"@logtail/tools@^0.4.10":
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/@logtail/tools/-/tools-0.4.10.tgz#79158f9bb4965710c037adfca4555b90335bb942"
+  integrity sha512-F+BCUIBXz8wf8DBfVuF4X6R9PWBrIhv+Bbvn9ywwvkWMCbkb+nd3nObBHGXar528NZis0CAz5oHXRuwslwRIpQ==
   dependencies:
     "@logtail/types" "^0.4.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,6 +483,16 @@
     "@types/node" "*"
     jest-mock "^29.6.3"
 
+"@jest/environment@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
+  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
+  dependencies:
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+
 "@jest/expect-utils@^29.6.4":
   version "29.6.4"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.6.4.tgz#17c7dfe6cec106441f218b0aff4b295f98346679"
@@ -521,6 +531,18 @@
     jest-message-util "^29.6.3"
     jest-mock "^29.6.3"
     jest-util "^29.6.3"
+
+"@jest/fake-timers@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
+  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@types/node" "*"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
 
 "@jest/globals@^29.6.4":
   version "29.6.4"
@@ -1500,6 +1522,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -1610,6 +1637,15 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/jsdom@^20.0.0":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
+  integrity sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
+
 "@types/minimatch@*":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
@@ -1640,6 +1676,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/tough-cookie@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.3.tgz#3d06b6769518450871fbc40770b7586334bdfd90"
+  integrity sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1669,17 +1710,30 @@ JSONStream@^1.0.4, JSONStream@^1.3.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-acorn-walk@^8.1.1:
+acorn-globals@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"
+  integrity sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==
+  dependencies:
+    acorn "^8.1.0"
+    acorn-walk "^8.0.2"
+
+acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1:
+acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.1:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
@@ -1690,6 +1744,13 @@ agent-base@4, agent-base@^4.3.0:
   integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
   dependencies:
     es6-promisify "^5.0.0"
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 agent-base@~4.2.1:
   version "4.2.1"
@@ -2405,7 +2466,7 @@ columnify@^1.5.4:
     strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2617,6 +2678,23 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2643,6 +2721,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
+  integrity sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -2654,6 +2741,13 @@ debug@3.1.0:
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
+
+debug@4, debug@^4.1.0, debug@^4.1.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -2668,13 +2762,6 @@ debug@^3.1.0:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -2693,6 +2780,11 @@ decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decimal.js@^10.4.2:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
+  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
 decode-uri-component@^0.2.0:
   version "0.2.2"
@@ -2801,6 +2893,13 @@ dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
+
 dot-prop@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
@@ -2871,6 +2970,11 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -2989,10 +3093,31 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-esprima@^4.0.0:
+escodegen@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+  optionalDependencies:
+    source-map "~0.6.1"
+
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -3226,6 +3351,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -3647,6 +3781,13 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -3665,6 +3806,15 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -3682,6 +3832,14 @@ https-proxy-agent@^2.2.3:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -3694,19 +3852,19 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+iconv-lite@0.6.3, iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@^0.6.2:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
-  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -4061,6 +4219,11 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -4337,6 +4500,20 @@ jest-each@^29.6.3:
     jest-util "^29.6.3"
     pretty-format "^29.6.3"
 
+jest-environment-jsdom@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f"
+  integrity sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/jsdom" "^20.0.0"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
+    jsdom "^20.0.0"
+
 jest-environment-node@^29.6.4:
   version "29.6.4"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.6.4.tgz#4ce311549afd815d3cafb49e60a1e4b25f06d29f"
@@ -4406,6 +4583,21 @@ jest-message-util@^29.5.0, jest-message-util@^29.6.3:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.5.0.tgz#26e2172bcc71d8b0195081ff1f146ac7e1518aed"
@@ -4423,6 +4615,15 @@ jest-mock@^29.5.0, jest-mock@^29.6.3:
     "@jest/types" "^29.6.3"
     "@types/node" "*"
     jest-util "^29.6.3"
+
+jest-mock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
+  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-util "^29.7.0"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.3"
@@ -4562,6 +4763,18 @@ jest-util@^29.0.0, jest-util@^29.5.0, jest-util@^29.6.3:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-validate@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.6.3.tgz#a75fca774cfb1c5758c70d035d30a1f9c2784b4d"
@@ -4625,6 +4838,38 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
+jsdom@^20.0.0:
+  version "20.0.3"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db"
+  integrity sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==
+  dependencies:
+    abab "^2.0.6"
+    acorn "^8.8.1"
+    acorn-globals "^7.0.0"
+    cssom "^0.5.0"
+    cssstyle "^2.3.0"
+    data-urls "^3.0.2"
+    decimal.js "^10.4.2"
+    domexception "^4.0.0"
+    escodegen "^2.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.2"
+    parse5 "^7.1.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.2"
+    w3c-xmlserializer "^4.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+    ws "^8.11.0"
+    xml-name-validator "^4.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -5422,6 +5667,11 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
 
+nwsapi@^2.2.2:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
+  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -5690,6 +5940,13 @@ parse-url@^6.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5@^7.0.0, parse5@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
+  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+  dependencies:
+    entities "^4.4.0"
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -5833,6 +6090,15 @@ pretty-format@^29.0.0, pretty-format@^29.6.3:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -5888,7 +6154,7 @@ protoduck@^5.0.1:
   dependencies:
     genfun "^5.0.0"
 
-psl@^1.1.28:
+psl@^1.1.28, psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
@@ -5954,6 +6220,11 @@ query-string@^6.13.8:
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -6182,6 +6453,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6314,6 +6590,13 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.2"
@@ -6499,7 +6782,7 @@ source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -6821,6 +7104,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.19"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
@@ -6956,6 +7244,16 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+tough-cookie@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -6970,6 +7268,13 @@ tr46@^1.0.1:
   integrity sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==
   dependencies:
     punycode "^2.1.0"
+
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
+    punycode "^2.1.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -7186,6 +7491,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -7218,6 +7528,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"
@@ -7279,6 +7597,13 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+w3c-xmlserializer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz#aebdc84920d806222936e3cdce408e32488a3073"
+  integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -7302,6 +7627,31 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -7451,6 +7801,21 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+ws@^8.11.0:
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.1.tgz#4b9586b4f70f9e6534c7bb1d3dc0baa8b8cf01e0"
+  integrity sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Improves tests by ensuring they will fail during an unexpected exception, and by using `jsdom` test environment for Browser tests.

Previously, `nock` was not working correctly and tests were making actual requests to Better Stack. The requests failed (401 Unauthorized), but the exception was ignored and tests passed.

Also, tests currently do not output anything apart from test results (no console output seeps through)