### PR TITLE
Add docs URL with details to warning message

### DIFF
--- a/packages/edge/src/edge.test.ts
+++ b/packages/edge/src/edge.test.ts
@@ -98,7 +98,8 @@ describe("edge tests", () => {
     expect((console.warn as Mock).mock.calls).toHaveLength(1);
     expect((console.warn as Mock).mock.calls[0][0]).toBe(
       "ExecutionContext hasn't been passed to the `log` method, which means syncing logs cannot be guaranteed. " +
-        "To ensure your logs will reach Better Stack, use `logger.withExecutionContext(ctx)` to log in your handler function.",
+        "To ensure your logs will reach Better Stack, use `logger.withExecutionContext(ctx)` to log in your handler function. " +
+        "See https://betterstack.com/docs/logs/js-edge-execution-context/ for details.",
     );
   });
 

--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -85,7 +85,8 @@ export class Edge extends Base {
 
       const warningMessage =
         "ExecutionContext hasn't been passed to the `log` method, which means syncing logs cannot be guaranteed. " +
-        "To ensure your logs will reach Better Stack, use `logger.withExecutionContext(ctx)` to log in your handler function.";
+        "To ensure your logs will reach Better Stack, use `logger.withExecutionContext(ctx)` to log in your handler function. " +
+        "See https://betterstack.com/docs/logs/js-edge-execution-context/ for details.";
       console.warn(warningMessage);
       this.log(warningMessage, LogLevel.Warn, stackContext).catch(() => {});
 


### PR DESCRIPTION
Adds https://betterstack.com/docs/logs/js-edge-execution-context/ that redirects to a new docs article, to help with the possible execution context issue in #78 