### PR TITLE
Fix type StackContextHint

### DIFF
--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -102,7 +102,7 @@ export enum LogLevel {
  */
 export type ContextKey = any;
 export type Context = { [key: string]: ContextKey };
-export type StackContextHint = { fileName: string; methodNames: [string] };
+export type StackContextHint = { fileName: string; methodNames: string[] };
 
 /**
  * Interface representing a minimal Logtail log


### PR DESCRIPTION
`[string]`: an array with exactly 1 string
`string[]`: an array of strings with any length