### PR TITLE
L-699 [edge] Allow to suppress warning about missing execution context

### DIFF
--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -4,7 +4,7 @@ import {
   Context,
   ILogLevel,
   ILogtailLog,
-  ILogtailOptions,
+  ILogtailEdgeOptions,
   LogLevel,
 } from "@logtail/types";
 import { Base } from "@logtail/core";
@@ -20,8 +20,12 @@ type Message = string | Error;
 export class Edge extends Base {
   private _warnedAboutMissingCtx: Boolean = false;
 
-  public constructor(sourceToken: string, options?: Partial<ILogtailOptions>) {
+  private warnAboutMissingExecutionContext: Boolean;
+
+  public constructor(sourceToken: string, options?: Partial<ILogtailEdgeOptions>) {
     super(sourceToken, options);
+
+    this.warnAboutMissingExecutionContext = options?.warnAboutMissingExecutionContext ?? true;
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
@@ -80,7 +84,7 @@ export class Edge extends Base {
 
     if (ctx) {
       ctx.waitUntil(log);
-    } else if (!this._warnedAboutMissingCtx) {
+    } else if (this.warnAboutMissingExecutionContext && !this._warnedAboutMissingCtx) {
       this._warnedAboutMissingCtx = true;
 
       const warningMessage =

--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -20,12 +20,16 @@ type Message = string | Error;
 export class Edge extends Base {
   private _warnedAboutMissingCtx: Boolean = false;
 
-  private warnAboutMissingExecutionContext: Boolean;
+  private readonly warnAboutMissingExecutionContext: Boolean;
 
-  public constructor(sourceToken: string, options?: Partial<ILogtailEdgeOptions>) {
+  public constructor(
+    sourceToken: string,
+    options?: Partial<ILogtailEdgeOptions>,
+  ) {
     super(sourceToken, options);
 
-    this.warnAboutMissingExecutionContext = options?.warnAboutMissingExecutionContext ?? true;
+    this.warnAboutMissingExecutionContext =
+      options?.warnAboutMissingExecutionContext ?? true;
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
@@ -84,7 +88,10 @@ export class Edge extends Base {
 
     if (ctx) {
       ctx.waitUntil(log);
-    } else if (this.warnAboutMissingExecutionContext && !this._warnedAboutMissingCtx) {
+    } else if (
+      this.warnAboutMissingExecutionContext &&
+      !this._warnedAboutMissingCtx
+    ) {
       this._warnedAboutMissingCtx = true;
 
       const warningMessage =

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -80,6 +80,12 @@ export interface ILogtailOptions {
    **/
   sendLogsToBetterStack: boolean;
 }
+export interface ILogtailEdgeOptions extends ILogtailOptions {
+  /**
+   * Boolean to produce a warning when ExecutionContext hasn't been passed to the `log` method
+   **/
+  warnAboutMissingExecutionContext: boolean;
+}
 
 export type ILogLevel = LogLevel | string;
 export enum LogLevel {


### PR DESCRIPTION
Resolves #88 

Example usage with disabled ExecutionContext warnings:

```js
import { Logtail } from "@logtail/edge"

const logger = new Logtail("<BETTER_STACK_SOURCE_TOKEN>", { warnAboutMissingExecutionContext: false })

export default {
  async fetch(request, env) {
    logger.info("Logging with structured data.", { field: "context value", myArray: [1, 2, 3] });
    logger.warn("Warning: This function is just Hello World.");

    return new Response('Hello world!');
  },
};
```