### PR TITLE
L-834 [node][edge] Serialize Error in context via serialize-error

### DIFF
--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -52,6 +52,7 @@
     "@msgpack/msgpack": "^2.5.1",
     "@types/stack-trace": "^0.0.29",
     "minimatch": "^3.0.4",
+    "serialize-error": "^8.1.0",
     "stack-trace": "^0.0.10"
   },
   "gitHead": "0f816cacc21b352576a5707741f9151aa1481041"

--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -1,4 +1,5 @@
 import { encode } from "@msgpack/msgpack";
+import { serializeError } from "serialize-error";
 
 import {
   Context,
@@ -176,11 +177,7 @@ export class Edge extends Base {
 
       return value.toISOString();
     } else if (value instanceof Error) {
-      return {
-        name: value.name,
-        message: value.message,
-        stack: value.stack?.split("\n"),
-      };
+      return serializeError(value);
     } else if (
       (typeof value === "object" || Array.isArray(value)) &&
       (maxDepth < 1 || visitedObjects.has(value))

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -52,6 +52,7 @@
     "@types/stack-trace": "^0.0.29",
     "cross-fetch": "^3.0.4",
     "minimatch": "^3.0.4",
+    "serialize-error": "^8.1.0",
     "stack-trace": "^0.0.10"
   },
   "gitHead": "0f816cacc21b352576a5707741f9151aa1481041"

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,4 +1,5 @@
 import { Duplex, Writable } from "stream";
+import { serializeError } from "serialize-error";
 
 import fetch from "cross-fetch";
 import { encode } from "@msgpack/msgpack";
@@ -131,11 +132,7 @@ export class Node extends Base {
 
       return value.toISOString();
     } else if (value instanceof Error) {
-      return {
-        name: value.name,
-        message: value.message,
-        stack: value.stack?.split("\n"),
-      };
+      return serializeError(value);
     } else if (
       (typeof value === "object" || Array.isArray(value)) &&
       (maxDepth < 1 || visitedObjects.has(value))


### PR DESCRIPTION
Improves #95 and uses `serialize-error` for serialization in context as well as in message.

Resolves #90 