### PR TITLE
Undefined handling for results from stack-trace.get

### DIFF
--- a/packages/edge/src/context.ts
+++ b/packages/edge/src/context.ts
@@ -29,7 +29,7 @@ export function getStackContext(logtail: Edge): Context {
 function getCallingFrame(logtail: Edge): StackFrame | null {
   for (let fn of [logtail.warn, logtail.error, logtail.info, logtail.debug, logtail.log]) {
     const stack = stackTrace.get(fn as any);
-    if (stack.length > 0) return getRelevantStackFrame(stack);
+    if (stack?.length > 0) return getRelevantStackFrame(stack);
   }
 
   return null;

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -35,7 +35,7 @@ export function getStackContext(logtail: Node, stackContextHint?: StackContextHi
 function getCallingFrame(logtail: Node, stackContextHint?: StackContextHint): StackFrame | null {
   for (let fn of [logtail.warn, logtail.error, logtail.info, logtail.debug, logtail.log]) {
     const stack = stackTrace.get(fn as any);
-    if (stack.length > 0) return getRelevantStackFrame(stack, stackContextHint);
+    if (stack?.length > 0) return getRelevantStackFrame(stack, stackContextHint);
   }
 
   return null;


### PR DESCRIPTION
Mongo Realm node environment is said to intentionally truncate the stack trace, and this results in TypeError