### PR TITLE
Add Node 22.x to CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
<img width="754" alt="image" src="https://github.com/logtail/logtail-js/assets/10008612/f3dbcb6c-a497-49be-811b-0306f33bd911">

https://nodejs.org/en/about/previous-releases