### PR TITLE
Call logtail.flush() when LogtailTransport (winston) is closed

### DIFF
--- a/packages/winston/src/winston.test.ts
+++ b/packages/winston/src/winston.test.ts
@@ -229,7 +229,7 @@ describe("Winston logging tests", () => {
     });
 
     const finished = new Promise<void>(resolve => {
-      logger.on('finish', resolve);
+      logger.on("finish", resolve);
     });
 
     // Act

--- a/packages/winston/src/winston.test.ts
+++ b/packages/winston/src/winston.test.ts
@@ -212,4 +212,36 @@ describe("Winston logging tests", () => {
     const context = logs[0].context;
     expect(context.runtime.file).toMatch("winston.test.ts");
   });
+
+  it("should flush logtail when the logger is closed", async () => {
+    let logs: ILogtailLog[] = [];
+
+    const logtail = new Logtail("test", { throwExceptions: true });
+
+    logtail.setSync(async (_logs: ILogtailLog[]) => {
+      logs.push(..._logs);
+      return logs;
+    });
+
+    const logger = winston.createLogger({
+      level: LogLevel.Info,
+      transports: [new LogtailTransport(logtail)],
+    });
+
+    const finished = new Promise<void>(resolve => {
+      logger.on('finish', resolve);
+    });
+
+    // Act
+    logger.info("a test message");
+    logger.end();
+
+    await finished;
+
+    // Should be exactly one log
+    expect(logs.length).toBe(1);
+
+    // Message should match
+    expect(logs[0].message).toBe("a test message");
+  });
 });

--- a/packages/winston/src/winston.ts
+++ b/packages/winston/src/winston.ts
@@ -11,7 +11,16 @@ const stackContextHint = {
 
 export class LogtailTransport extends Transport {
   public constructor(private _logtail: Logtail, opts?: Transport.TransportStreamOptions) {
-    super(opts);
+    super({
+      ...opts,
+      close: () => {
+        this._logtail.flush().then(() => {
+          if (opts?.close) {
+            opts.close();
+          }
+        });
+      },
+    });
   }
 
   public log(info: LogEntry, cb: Function) {

--- a/packages/winston/src/winston.ts
+++ b/packages/winston/src/winston.ts
@@ -11,7 +11,17 @@ const stackContextHint = {
 
 export class LogtailTransport extends Transport {
   public constructor(private _logtail: Logtail, opts?: Transport.TransportStreamOptions) {
-    super(opts);
+    super({
+      ...opts,
+      close: () => {
+        this._logtail.flush()
+          .then(() => {
+            if (opts?.close) {
+              opts.close();
+            }
+          });
+      },
+    });
   }
 
   public log(info: LogEntry, cb: Function) {

--- a/packages/winston/src/winston.ts
+++ b/packages/winston/src/winston.ts
@@ -11,17 +11,7 @@ const stackContextHint = {
 
 export class LogtailTransport extends Transport {
   public constructor(private _logtail: Logtail, opts?: Transport.TransportStreamOptions) {
-    super({
-      ...opts,
-      close: () => {
-        this._logtail.flush()
-          .then(() => {
-            if (opts?.close) {
-              opts.close();
-            }
-          });
-      },
-    });
+    super(opts);
   }
 
   public log(info: LogEntry, cb: Function) {


### PR DESCRIPTION
We started using `@logtail/node` with `winston` and noticed that when a winston logger closes, `LogtailTransport` does not flush buffered messages to `logtail`. This is especially annoying when trying to log unhandled exceptions that cause the process to exit.

The base winston `Transport` class accepts a `close()` callback in the constructor options object, which is called whenever the transport instance is "unpiped" from the logger. This PR wraps any `close()` callback passed to the constructor of `LogtailTransport` with the flushing logic. 

This PR also adds a unit test for `LogtailTransport`. This test fails without the changes in the constructor.