### PR TITLE
[tools] throttle.test.ts: Introduce 0.2ms tolerance

### DIFF
--- a/packages/tools/src/batch.test.ts
+++ b/packages/tools/src/batch.test.ts
@@ -151,8 +151,9 @@ describe("batch tests", () => {
 
     // Expect time to have taken at least this long...
     const expectedTime = ((numberOfLogs / batchSize) * throttleResolveAfter) / maxThrottle;
+    const toleranceMilliseconds = 0.2;
 
-    expect(end).toBeGreaterThanOrEqual(expectedTime);
+    expect(end).toBeGreaterThanOrEqual(expectedTime - toleranceMilliseconds);
   });
 
   it("should send after flush (with long timeout)", async () => {

--- a/packages/tools/src/throttle.test.ts
+++ b/packages/tools/src/throttle.test.ts
@@ -46,8 +46,9 @@ describe("Throttle tests", () => {
 
     // Expect time to have taken (numberOfPromises / max) * throttleTime
     const expectedTime = (numberOfPromises / max) * throttleTime;
+    const toleranceMilliseconds = 0.2;
 
-    expect(end).toBeGreaterThanOrEqual(expectedTime);
+    expect(end).toBeGreaterThanOrEqual(expectedTime - toleranceMilliseconds);
   });
 
   it("should handle rejections", async () => {


### PR DESCRIPTION
I've noticed some failures of our throttling test:

https://github.com/logtail/logtail-js/actions/runs/10183600721/job/28168945732
https://github.com/logtail/logtail-js/actions/runs/10183600721/job/28169441778

Eventually, the test passes:

https://github.com/logtail/logtail-js/actions/runs/10183600721/job/28169997282

I'd suggest adding 0.2ms tolerance to the test.