### PR TITLE
Make sure both locked and latest dependencies are used for E2E testing

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -47,7 +47,7 @@ jobs:
           fi
         working-directory: ./example-project
 
-  tests-bun:
+  bun:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ph/end-to-end-tests
   schedule:
     - cron: "20 5 * * *"
   workflow_dispatch:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x, 22.x]
+        dependencies: [install, update]
       fail-fast: false
 
     steps:
@@ -29,7 +30,7 @@ jobs:
           cache-dependency-path: example-project/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ${{ matrix.dependencies }}
         working-directory: ./example-project
 
       - name: Run example project with valid token
@@ -52,6 +53,7 @@ jobs:
     strategy:
       matrix:
         bun-version: [latest, 1.0.0]
+        dependencies: [install, update]
       fail-fast: false
 
     steps:
@@ -63,7 +65,7 @@ jobs:
           bun-version: ${{ matrix.bun-version }}
 
       - name: Install dependencies
-        run: bun install
+        run: bun ${{ matrix.dependencies }}
         working-directory: ./example-project
 
       - name: Run example project with valid token

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - ph/end-to-end-tests
   schedule:
     - cron: "20 5 * * *"
   workflow_dispatch:


### PR DESCRIPTION
This will ensure latest dependencies are being tested even when `example-project/package-lock.json` is not updated.