### PR TITLE
[browser] Improve compatibility of getCurrentContext

### DIFF
--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -69,7 +69,7 @@ export class Browser extends Base {
   protected getCurrentContext(): Context {
     const context: Context = {};
 
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       context.url = window.location?.href;
       context.device_pixel_ratio = window.devicePixelRatio;
       context.screen_width = window.screen?.width;
@@ -77,7 +77,7 @@ export class Browser extends Base {
       context.window_width = window.innerWidth;
       context.window_height = window.innerHeight;
     }
-    if (typeof navigator !== 'undefined') {
+    if (typeof navigator !== "undefined") {
       context.user_locale = (navigator as any).userLanguage || navigator.language;
       context.user_agent = navigator.userAgent;
     }

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -67,18 +67,22 @@ export class Browser extends Base {
   }
 
   protected getCurrentContext(): Context {
-    return {
-      context: {
-        url: window.location.href,
-        user_locale: (navigator as any).userLanguage || navigator.language,
-        user_agent: navigator.userAgent,
-        device_pixel_ratio: window.devicePixelRatio,
-        screen_width: window.screen.width,
-        screen_height: window.screen.height,
-        window_width: window.innerWidth,
-        window_height: window.innerHeight,
-      },
-    };
+    const context: Context = {};
+
+    if (typeof window !== 'undefined') {
+      context.url = window.location?.href;
+      context.device_pixel_ratio = window.devicePixelRatio;
+      context.screen_width = window.screen?.width;
+      context.screen_height = window.screen?.height;
+      context.window_width = window.innerWidth;
+      context.window_height = window.innerHeight;
+    }
+    if (typeof navigator !== 'undefined') {
+      context.user_locale = (navigator as any).userLanguage || navigator.language;
+      context.user_agent = navigator.userAgent;
+    }
+
+    return context;
   }
 
   private configureFlushOnPageLeave(): void {


### PR DESCRIPTION
Resolves #96 

Ensures `@logtail/browser` can be used even when `Window` or `Navigator` are not present, which may be the case for example in React Native environment.