### PR TITLE
[pino] Omit misleading context when executed in thread-stream worker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,5 +10,5 @@ We are using `yarn` to manage dependencies.
 4. To use `example-project` with the locally built packages
    1. Make sure all dependencies are installed and all packages built
    2. Run `npm install` in the `/example-project` directory
-   3. Run `yarn boostrap-example` in the root directory
+   3. Run `yarn bootstrap-example` in the root directory
    4. To run the example project, run `node index.js <source-token>` in the `/example-project` directory

--- a/packages/node/src/context.ts
+++ b/packages/node/src/context.ts
@@ -41,7 +41,7 @@ function getCallingFrame(logtail: Node, stackContextHint?: StackContextHint): St
   return null;
 }
 
-function getRelevantStackFrame(frames: StackFrame[], stackContextHint?: StackContextHint): StackFrame {
+function getRelevantStackFrame(frames: StackFrame[], stackContextHint?: StackContextHint): StackFrame | null {
   if (stackContextHint) {
     frames.reverse();
     let index = frames.findIndex((frame) => {
@@ -55,6 +55,11 @@ function getRelevantStackFrame(frames: StackFrame[], stackContextHint?: StackCon
     if (index > 0) {
       return frames[index - 1];
     }
+
+    if (stackContextHint.required) {
+      return null;
+    }
+
     return frames[frames.length - 1];
   }
 

--- a/packages/pino/src/pino.ts
+++ b/packages/pino/src/pino.ts
@@ -23,6 +23,7 @@ export interface IPinoLogtailOptions {
 const stackContextHint = {
   fileName: "node_modules/pino",
   methodNames: ["log", "fatal", "error", "warn", "info", "debug", "trace", "silent"],
+  required: true,
 };
 
 export async function logtailTransport(options: IPinoLogtailOptions) {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -118,7 +118,7 @@ export enum LogLevel {
  */
 export type ContextKey = any;
 export type Context = { [key: string]: ContextKey };
-export type StackContextHint = { fileName: string; methodNames: string[] };
+export type StackContextHint = { fileName: string; methodNames: string[]; required?: true };
 
 /**
  * Interface representing a minimal Logtail log


### PR DESCRIPTION
Fixes #124 

Unfortunately, the code is executed inside `thread-stream` worker and doesn't have access to stack trace or the main file name.

I'm keeping the functionality provided the data can be accessed, it might work in a specific Pino version or with a specific setting. If the `stackContextHint` is not recognized in stack trace, omit the context data.

Only affects Pino.

Before:

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/281e923c-faa3-4301-834b-0c5fc4670b42">

After:

<img width="1050" alt="image" src="https://github.com/user-attachments/assets/29c961b4-19ba-428b-af51-bd8ed969ba70">
