### PR TITLE
refactor: remove dependency cross-fetch

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   projects: [
     {
-      displayName: 'Node',
+      displayName: "Node",
       coverageDirectory: "coverage",
       coveragePathIgnorePatterns: ["node_modules/", "dist/"],
       moduleDirectories: ["node_modules"],
@@ -10,24 +10,25 @@ module.exports = {
       testMatch: ["<rootDir>/packages/**/*.test.ts"],
       testPathIgnorePatterns: ["/node_modules/", "/dist/", "/packages/browser/", "/packages/edge/"],
       transform: {
-        "^.+\\.ts$": ["ts-jest", "tsconfig.json"]
+        "^.+\\.ts$": ["ts-jest", "tsconfig.json"],
       },
     },
     {
-      displayName: 'Browser',
+      displayName: "Browser",
       coverageDirectory: "coverage",
       coveragePathIgnorePatterns: ["node_modules/", "dist/"],
       moduleDirectories: ["node_modules"],
       moduleFileExtensions: ["ts", "js"],
-      testEnvironment: "jsdom",
+      // https://mswjs.io/docs/migrations/1.x-to-2.x#requestresponsetextencoder-is-not-defined-jest
+      testEnvironment: "jest-fixed-jsdom",
       testMatch: ["<rootDir>/packages/browser/**/*.test.ts"],
       testPathIgnorePatterns: ["/node_modules/", "/dist/"],
       transform: {
-        "^.+\\.ts$": ["ts-jest", "tsconfig.json"]
+        "^.+\\.ts$": ["ts-jest", "tsconfig.json"],
       },
     },
     {
-      displayName: 'Edge',
+      displayName: "Edge",
       coverageDirectory: "coverage",
       coveragePathIgnorePatterns: ["node_modules/", "dist/"],
       moduleDirectories: ["node_modules"],
@@ -36,8 +37,8 @@ module.exports = {
       testMatch: ["<rootDir>/packages/edge/**/*.test.ts"],
       testPathIgnorePatterns: ["/node_modules/", "/dist/"],
       transform: {
-        "^.+\\.ts$": ["ts-jest", "tsconfig.json"]
+        "^.+\\.ts$": ["ts-jest", "tsconfig.json"],
       },
     },
-  ]
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/node": "^20.14.9",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-fixed-jsdom": "^0.0.9",
     "lerna": "^8.1.5",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.2",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -42,15 +42,14 @@
     "@logtail/types": "^0.5.2",
     "@types/nock": "^11.1.0",
     "@types/webpack": "^5.28.2",
-    "nock": "^13.3.3",
+    "nock": "^14.0.0-beta.19",
     "ts-loader": "^9.5.1",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
     "@logtail/core": "^0.5.2",
-    "@logtail/tools": "^0.5.2",
-    "cross-fetch": "^4.0.0"
+    "@logtail/tools": "^0.5.2"
   },
   "gitHead": "0f816cacc21b352576a5707741f9151aa1481041"
 }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -42,7 +42,7 @@
     "@logtail/types": "^0.5.2",
     "@types/nock": "^11.1.0",
     "@types/webpack": "^5.28.2",
-    "nock": "^14.0.0-beta.19",
+    "nock": "^14.0.1",
     "ts-loader": "^9.5.1",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4"

--- a/packages/browser/src/browser.ts
+++ b/packages/browser/src/browser.ts
@@ -1,5 +1,3 @@
-import "cross-fetch/polyfill";
-
 import { Context, ILogLevel, ILogtailLog, ILogtailOptions } from "@logtail/types";
 import { Base } from "@logtail/core";
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -39,14 +39,13 @@
   "devDependencies": {
     "@types/fetch-mock": "^7.3.1",
     "@types/nock": "^11.1.0",
-    "nock": "^13.3.3"
+    "nock": "^14.0.0-beta.19"
   },
   "dependencies": {
     "@logtail/core": "^0.5.2",
     "@logtail/types": "^0.5.2",
     "@msgpack/msgpack": "^2.5.1",
     "@types/stack-trace": "^0.0.33",
-    "cross-fetch": "^4.0.0",
     "minimatch": "^9.0.5",
     "serialize-error": "8.1.0",
     "stack-trace": "0.0.10"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/fetch-mock": "^7.3.1",
     "@types/nock": "^11.1.0",
-    "nock": "^14.0.0-beta.19"
+    "nock": "^14.0.1"
   },
   "dependencies": {
     "@logtail/core": "^0.5.2",

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,6 +1,5 @@
 import { Duplex, Writable } from "stream";
 
-import fetch from "cross-fetch";
 import { encode } from "@msgpack/msgpack";
 
 import { Context, ILogLevel, ILogtailLog, ILogtailOptions, LogLevel, StackContextHint } from "@logtail/types";

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -23,22 +23,19 @@ export class Node extends Base {
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
-      const request = this.getHttpModule().request(
-        this._options.endpoint,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/msgpack',
-            'Authorization': `Bearer ${this._sourceToken}`,
-            'User-Agent': 'logtail-js(node)',
-          },
-          agent,
-        }
-      );
+      const request = this.getHttpModule().request(this._options.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/msgpack",
+          Authorization: `Bearer ${this._sourceToken}`,
+          "User-Agent": "logtail-js(node)",
+        },
+        agent,
+      });
 
-      const response : http.IncomingMessage = await new Promise((resolve, reject) => {
-        request.on('response', resolve);
-        request.on('error', reject);
+      const response: http.IncomingMessage = await new Promise((resolve, reject) => {
+        request.on("response", resolve);
+        request.on("error", reject);
         request.write(this.encodeAsMsgpack(logs));
         request.end();
       });
@@ -101,12 +98,12 @@ export class Node extends Base {
   private createAgent() {
     const nodeOptions = this._options as ILogtailNodeOptions;
     const family = nodeOptions.useIPv6 ? 6 : 4;
-    return new (this.getHttpModule()).Agent({
+    return new (this.getHttpModule().Agent)({
       family,
     });
   }
 
   private getHttpModule(): typeof http | typeof https {
-    return this._options.endpoint.startsWith('https') ? https : http;
+    return this._options.endpoint.startsWith("https") ? https : http;
   }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -30,12 +30,10 @@
   "devDependencies": {
     "@types/nock": "^11.1.0",
     "@types/source-map": "^0.5.7",
-    "cross-fetch": "^4.0.0",
-    "nock": "^13.3.3"
+    "nock": "^14.0.0-beta.19"
   },
   "dependencies": {
-    "@logtail/types": "^0.5.2",
-    "cross-fetch": "^4.0.0"
+    "@logtail/types": "^0.5.2"
   },
   "gitHead": "0f816cacc21b352576a5707741f9151aa1481041"
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/nock": "^11.1.0",
     "@types/source-map": "^0.5.7",
-    "nock": "^14.0.0-beta.19"
+    "nock": "^14.0.1"
   },
   "dependencies": {
     "@logtail/types": "^0.5.2"

--- a/packages/tools/src/batch.test.ts
+++ b/packages/tools/src/batch.test.ts
@@ -1,5 +1,4 @@
 import nock from "nock";
-import fetch from "cross-fetch";
 import { ILogtailLog, LogLevel } from "@logtail/types";
 import makeBatch, { calculateJsonLogSizeBytes } from "./batch";
 import makeThrottle from "./throttle";

--- a/packages/tools/src/retry.test.ts
+++ b/packages/tools/src/retry.test.ts
@@ -1,5 +1,4 @@
 import { ILogtailLog, LogLevel } from "@logtail/types";
-import fetch from "cross-fetch";
 import nock from "nock";
 import makeRetry from "./retry";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,6 +735,18 @@
   resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.8.0.tgz#4210deb771ee3912964f14a15ddfb5ff877e70b9"
   integrity sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==
 
+"@mswjs/interceptors@^0.37.3":
+  version "0.37.5"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.37.5.tgz#9ce40c56be02b43fcbdb51b63f47e69fc4aaabe6"
+  integrity sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1107,6 +1119,24 @@
   integrity sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
+
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -2619,13 +2649,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
-  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
-  dependencies:
-    node-fetch "^2.6.12"
-
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4060,6 +4083,11 @@ is-negative-zero@^2.0.3:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
 
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
+
 is-number-object@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
@@ -4408,6 +4436,11 @@ jest-environment-node@^29.7.0:
     "@types/node" "*"
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
+
+jest-fixed-jsdom@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/jest-fixed-jsdom/-/jest-fixed-jsdom-0.0.9.tgz#12d594d3edfdd2ae09fd1f6c6c4e68baf4c4a1a7"
+  integrity sha512-KPfqh2+sn5q2B+7LZktwDcwhCpOpUSue8a1I+BcixWLOQoEVyAjAGfH+IYZGoxZsziNojoHGRTC8xRbB1wDD4g==
 
 jest-get-type@^29.6.3:
   version "29.6.3"
@@ -5443,12 +5476,21 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nock@*, nock@^13.3.3:
+nock@*:
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.4.tgz#8918f0addc70a63736170fef7106a9721e0dc479"
   integrity sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==
   dependencies:
     debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    propagate "^2.0.0"
+
+nock@^14.0.0-beta.19:
+  version "14.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.0-beta.19.tgz#6cfee5846a6ff9841dbd796b770bdb4ecfafe0d3"
+  integrity sha512-xqWQQZ/Hv01tj5uL7BE4j752hhB2MHP7aaEcTp/iDT1EHsh3TYZOIx4HHFL81yRc8KFx4pqb2P2OtuxKShKhjw==
+  dependencies:
+    "@mswjs/interceptors" "^0.37.3"
     json-stringify-safe "^5.0.1"
     propagate "^2.0.0"
 
@@ -5459,7 +5501,7 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.12, node-fetch@^2.6.7:
+node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -5771,6 +5813,11 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -6773,6 +6820,11 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
 string-length@^4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5485,10 +5485,10 @@ nock@*:
     json-stringify-safe "^5.0.1"
     propagate "^2.0.0"
 
-nock@^14.0.0-beta.19:
-  version "14.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.0-beta.19.tgz#6cfee5846a6ff9841dbd796b770bdb4ecfafe0d3"
-  integrity sha512-xqWQQZ/Hv01tj5uL7BE4j752hhB2MHP7aaEcTp/iDT1EHsh3TYZOIx4HHFL81yRc8KFx4pqb2P2OtuxKShKhjw==
+nock@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.1.tgz#62006248bbbc7637322c9fc73f90b93a431b4f5e"
+  integrity sha512-IJN4O9pturuRdn60NjQ7YkFt6Rwei7ZKaOwb1tvUIIqTgeD0SDDAX3vrqZD4wcXczeEy/AsUXxpGpP/yHqV7xg==
   dependencies:
     "@mswjs/interceptors" "^0.37.3"
     json-stringify-safe "^5.0.1"


### PR DESCRIPTION
close https://github.com/logtail/logtail-js/issues/126

`cross-fetch` is not needed in the modern environments, as `fetch` is available in the browsers and Node >= 18.

To minimize the changes on the tests,
- `nock` is updated to v14 which supports native fetch
- `jest-fixed-jsdom` is used as the browser test environment due to https://mswjs.io/docs/migrations/1.x-to-2.x#requestresponsetextencoder-is-not-defined-jest