### PR TITLE
refactor: remove dependency serialize-error

### DIFF
--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -46,7 +46,6 @@
     "@msgpack/msgpack": "^2.5.1",
     "@types/stack-trace": "^0.0.33",
     "minimatch": "^9.0.5",
-    "serialize-error": "8.1.0",
     "stack-trace": "0.0.10"
   },
   "gitHead": "0f816cacc21b352576a5707741f9151aa1481041"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -48,7 +48,6 @@
     "@types/stack-trace": "^0.0.33",
     "cross-fetch": "^4.0.0",
     "minimatch": "^9.0.5",
-    "serialize-error": "8.1.0",
     "stack-trace": "0.0.10"
   },
   "gitHead": "0f816cacc21b352576a5707741f9151aa1481041"


### PR DESCRIPTION
Remove dependency `serialize-error` from package `edge` and `node` as there are no references in the code.

I was trying to upgrade `serialize-error` to close https://github.com/logtail/logtail-js/issues/128. Although I couldn't achieve that due to `serialize-error` becomes pure ESM package since [9.0](https://github.com/sindresorhus/serialize-error/releases/tag/v9.0.0) while this repository still generates CJS outputs, I found out `serialize-error` is not in used in some packages.