### PR TITLE
E2E tests: specify in.logs.betterstack.com ingesting host

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -2,8 +2,9 @@ name: E2E Tests
 
 on:
   push:
-    branches:
-      - master
+    paths:
+      - .github/workflows/end-to-end.yml
+      - example-project/
   schedule:
     - cron: "20 5 * * *"
   workflow_dispatch:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - .github/workflows/end-to-end.yml
-      - example-project/
+      - example-project/**
   schedule:
     - cron: "20 5 * * *"
   workflow_dispatch:

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -15,6 +15,7 @@ jobs:
 
     strategy:
       matrix:
+        infrastructure: [legacy, cloud]
         node-version: [16.x, 18.x, 20.x, 22.x]
         dependencies: [install, update]
       fail-fast: false
@@ -34,12 +35,17 @@ jobs:
         working-directory: ./example-project
 
       - name: Run example project with valid token
-        run: node index.js ${{ secrets.SOURCE_TOKEN }} in.logs.betterstack.com
+        env:
+          INGESTING_HOST: ${{ matrix.infrastructure == 'cloud' && secrets.CLOUD_INGESTING_HOST || 'in.logs.betterstack.com' }}
+          SOURCE_TOKEN: ${{ matrix.infrastructure == 'cloud' && secrets.CLOUD_SOURCE_TOKEN || secrets.SOURCE_TOKEN }}
+        run: node index.js ${{ env.SOURCE_TOKEN }} ${{ env.INGESTING_HOST }}
         working-directory: ./example-project
 
       - name: Run example project with invalid token
+        env:
+          INGESTING_HOST: ${{ matrix.infrastructure == 'cloud' && secrets.CLOUD_INGESTING_HOST || 'in.logs.betterstack.com' }}
         run: |
-          if node index.js INVALID_TOKEN in.logs.betterstack.com; then
+          if node index.js INVALID_TOKEN ${{ env.INGESTING_HOST }}; then
             echo "This should have failed but didn't"
             exit 1
           else
@@ -69,12 +75,17 @@ jobs:
         working-directory: ./example-project
 
       - name: Run example project with valid token
-        run: bun run index.js ${{ secrets.SOURCE_TOKEN }} in.logs.betterstack.com
+        env:
+          INGESTING_HOST: ${{ matrix.infrastructure == 'cloud' && secrets.CLOUD_INGESTING_HOST || 'in.logs.betterstack.com' }}
+          SOURCE_TOKEN: ${{ matrix.infrastructure == 'cloud' && secrets.CLOUD_SOURCE_TOKEN || secrets.SOURCE_TOKEN }}
+        run: bun run index.js ${{ env.SOURCE_TOKEN }} ${{ env.INGESTING_HOST }}
         working-directory: ./example-project
 
       - name: Run example project with invalid token
+        env:
+          INGESTING_HOST: ${{ matrix.infrastructure == 'cloud' && secrets.CLOUD_INGESTING_HOST || 'in.logs.betterstack.com' }}
         run: |
-          if bun run index.js INVALID_TOKEN in.logs.betterstack.com; then
+          if bun run index.js INVALID_TOKEN ${{ env.INGESTING_HOST }}; then
             echo "This should have failed but didn't"
             exit 1
           else

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -58,6 +58,7 @@ jobs:
 
     strategy:
       matrix:
+        infrastructure: [legacy, cloud]
         bun-version: [latest, 1.0.0]
         dependencies: [install, update]
       fail-fast: false

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -33,12 +33,12 @@ jobs:
         working-directory: ./example-project
 
       - name: Run example project with valid token
-        run: node index.js ${{ secrets.SOURCE_TOKEN }}
+        run: node index.js ${{ secrets.SOURCE_TOKEN }} in.logs.betterstack.com
         working-directory: ./example-project
 
       - name: Run example project with invalid token
         run: |
-          if node index.js INVALID_TOKEN; then
+          if node index.js INVALID_TOKEN in.logs.betterstack.com; then
             echo "This should have failed but didn't"
             exit 1
           else
@@ -68,12 +68,12 @@ jobs:
         working-directory: ./example-project
 
       - name: Run example project with valid token
-        run: bun run index.js ${{ secrets.SOURCE_TOKEN }}
+        run: bun run index.js ${{ secrets.SOURCE_TOKEN }} in.logs.betterstack.com
         working-directory: ./example-project
 
       - name: Run example project with invalid token
         run: |
-          if bun run index.js INVALID_TOKEN; then
+          if bun run index.js INVALID_TOKEN in.logs.betterstack.com; then
             echo "This should have failed but didn't"
             exit 1
           else

--- a/example-project/index.js
+++ b/example-project/index.js
@@ -16,7 +16,7 @@ const { Node: Logtail } = require("@logtail/js");
 // Create a logger from a Logtail class
 const logger = new Logtail(process.argv[2], {
   sendLogsToConsoleOutput: true,
-  endpoint: process.argv[3],
+  endpoint: `https://${process.argv[3]}`,
 });
 
 // Usage


### PR DESCRIPTION
Fixes E2E tests after changes in #133, prefixes the ingesting host with https:// before using it as endpoint

Before it was necessary to run `node index.js <source-token> https://<ingesting-host>`