### PR TITLE
Node: Default to IPv4 to support environments with problematic upstream IPv6 connectivity

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -58,9 +58,6 @@ const defaultOptions: ILogtailOptions = {
 
   // Function to be used to calculate size of logs in bytes (to evaluate batchSizeLimitKiB)
   calculateLogSizeBytes: calculateJsonLogSizeBytes,
-
-  // Use IPv6 for sending logs to Better Stack. Enable this if you are running on nodejs in an IPv6-only network.
-  useIPv6: false,
 };
 
 /**

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -58,6 +58,9 @@ const defaultOptions: ILogtailOptions = {
 
   // Function to be used to calculate size of logs in bytes (to evaluate batchSizeLimitKiB)
   calculateLogSizeBytes: calculateJsonLogSizeBytes,
+
+  // Use IPv6 for sending logs to Better Stack. Enable this if you are running on nodejs in an IPv6-only network.
+  useIPv6: false,
 };
 
 /**

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -5,7 +5,7 @@ import { fetch } from "cross-fetch";
 import http from "node:http";
 import https from "node:https";
 
-import { Context, ILogLevel, ILogtailLog, ILogtailOptions, LogLevel, StackContextHint } from "@logtail/types";
+import { Context, ILogLevel, ILogtailLog, ILogtailNodeOptions, LogLevel, StackContextHint } from "@logtail/types";
 import { Base } from "@logtail/core";
 
 import { getStackContext } from "./context";
@@ -17,10 +17,10 @@ export class Node extends Base {
    */
   private _writeStream?: Writable | Duplex;
 
-  public constructor(sourceToken: string, options?: Partial<ILogtailOptions>) {
+  public constructor(sourceToken: string, options?: Partial<ILogtailNodeOptions>) {
     super(sourceToken, options);
 
-    const agent = this.createAgent(this._options);
+    const agent = this.createAgent();
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
@@ -91,9 +91,10 @@ export class Node extends Base {
     return buffer;
   }
 
-  private createAgent(options: ILogtailOptions) {
-    const family = options.useIPv6 ? 6 : 4;
-    if (options.endpoint.startsWith("https")) {
+  private createAgent() {
+    const nodeOptions = this._options as ILogtailNodeOptions;
+    const family = nodeOptions.useIPv6 ? 6 : 4;
+    if (nodeOptions.endpoint.startsWith("https")) {
       return new https.Agent({
         family,
       });

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -86,6 +86,11 @@ export interface ILogtailOptions {
   sendLogsToBetterStack: boolean;
 
   /**
+   * Use IPv6 for sending logs to Better Stack. Enable this if you are running on nodejs in an IPv6-only network.
+   */
+  useIPv6: boolean;
+
+  /**
    * Function to be used to calculate size of logs in bytes (to evaluate batchSizeKiB). JSON length by default.
    **/
   calculateLogSizeBytes: (logs: ILogtailLog) => number;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -86,15 +86,18 @@ export interface ILogtailOptions {
   sendLogsToBetterStack: boolean;
 
   /**
-   * Use IPv6 for sending logs to Better Stack. Enable this if you are running on nodejs in an IPv6-only network.
-   */
-  useIPv6: boolean;
-
-  /**
    * Function to be used to calculate size of logs in bytes (to evaluate batchSizeKiB). JSON length by default.
    **/
   calculateLogSizeBytes: (logs: ILogtailLog) => number;
 }
+
+export interface ILogtailNodeOptions extends ILogtailOptions {
+  /**
+   * Use IPv6 for sending logs to Better Stack. Enable this if you are running on nodejs in an IPv6-only network.
+   */
+  useIPv6: boolean;
+}
+
 export interface ILogtailEdgeOptions extends ILogtailOptions {
   /**
    * Boolean to produce a warning when ExecutionContext hasn't been passed to the `log` method


### PR DESCRIPTION
Mostly to handle EC2 default internet gateways; the EC2 host reports it has an IPv6 address, but there is no upstream connectivity. Nodejs doesn't support happy-eyeballs, so we need to be more explicit.

Added a 'useIPv6' flag for users running in environments that only have IPv6 networking.