### PR TITLE
T-8088 Add gzip compression to node and edge sync functions

### DIFF
--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -23,14 +23,20 @@ export class Edge extends Base {
 
     // Sync function
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
+      // Compress the data using CompressionStream
+      const compressedData = await new Response(
+        new Blob([this.encodeAsMsgpack(logs)]).stream().pipeThrough(new CompressionStream("gzip"))
+      ).arrayBuffer();
+
       const res = await fetch(this._options.endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/msgpack",
+          "Content-Encoding": "gzip",
           Authorization: `Bearer ${this._sourceToken}`,
           "User-Agent": "logtail-js(edge)",
         },
-        body: this.encodeAsMsgpack(logs),
+        body: compressedData,
       });
 
       if (res.ok) {

--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -25,7 +25,7 @@ export class Edge extends Base {
     const sync = async (logs: ILogtailLog[]): Promise<ILogtailLog[]> => {
       // Compress the data using CompressionStream
       const compressedData = await new Response(
-        new Blob([this.encodeAsMsgpack(logs)]).stream().pipeThrough(new CompressionStream("gzip"))
+        new Blob([this.encodeAsMsgpack(logs)]).stream().pipeThrough(new CompressionStream("gzip")),
       ).arrayBuffer();
 
       const res = await fetch(this._options.endpoint, {


### PR DESCRIPTION
Adds gzip compression to sync functions in `node` and `edge` package (also used in packages such as `pino` or `winston`).

This should significantly lower the egress network traffic in backend services.

Wanted to add compression to `browser` package as well, but it would require an additional dependency (e.g. https://github.com/nodeca/pako) and is not worth the additional complexity imo. Requests from browsers tend to be smaller and the extra upload size is not much of an issue.

Planning on releasing this as `v0.5.5`.