### PR TITLE
T-9413 Limit queue length using maxQueuedMax option, and add timeout for Node.js

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -28,6 +28,9 @@ const defaultOptions: ILogtailOptions = {
   // Maximum number of sync requests to make concurrently
   syncMax: 5,
 
+  // Maximum number of sync requests that can be queued (-1 for unlimited queue)
+  syncQueuedMax: 100,
+
   // Length of the checked window for logs burst protection in milliseconds (0 to disable)
   burstProtectionMilliseconds: 5000,
 
@@ -115,7 +118,7 @@ class Logtail {
     this._options = { ...defaultOptions, ...options };
 
     // Create a throttler, for sync operations
-    const throttle = makeThrottle(this._options.syncMax);
+    const throttle = makeThrottle(this._options.syncMax, this._options.syncQueuedMax);
 
     // Sync after throttling
     const throttler = throttle((logs: any) => {

--- a/packages/tools/src/throttle.test.ts
+++ b/packages/tools/src/throttle.test.ts
@@ -75,4 +75,43 @@ describe("Throttle tests", () => {
 
     expect(errors).toEqual(numberOfPromises / 2);
   });
+
+  it("should drop requests when queue limit is exceeded", async () => {
+    let functionCallCount = 0;
+
+    // Create a function that takes some time to complete
+    const slowFunction = async (id: number) => {
+      functionCallCount++;
+      await new Promise(resolve => setTimeout(resolve, 100));
+      return `result ${id}`;
+    };
+
+    // Create throttle with max=1 (1 concurrent), queueMax=2 (2 queued)
+    const throttle = makeThrottle(1, 2);
+
+    const throttledFunction = throttle(slowFunction);
+
+    // Call 5 times quickly
+    const promises = [];
+    for (let i = 1; i <= 5; i++) {
+      promises.push(
+        throttledFunction(i)
+          .catch(err => {
+            if (err.message === "Queue max limit exceeded") {
+              return `dropped ${i}`;
+            }
+            throw err;
+          })
+      );
+    }
+
+    // Wait for all promises to settle
+    const results = await Promise.all(promises);
+
+    // Verify results
+    expect(functionCallCount).toBe(3); // 1 immediate + 2 queued = 3 total executed
+    
+    // Check that we got the expected mix of results and drops
+    expect(results).toStrictEqual(["result 1", "result 2", "result 3", "dropped 4", "dropped 5"]);
+  });
 });

--- a/packages/tools/src/throttle.ts
+++ b/packages/tools/src/throttle.ts
@@ -4,8 +4,12 @@ import { InferArgs } from "./types";
 /**
  * Create a throttle which runs up to `max` async functions at once
  * @param max - maximum number of async functions to run
+ * @param queueMax - maximum number of functions to queue (-1 = unlimited, default)
  */
-export default function makeThrottle<T extends (...args: any[]) => any>(max: number) {
+export default function makeThrottle<T extends (...args: any[]) => any>(
+  max: number,
+  queueMax: number = -1,
+) {
   // Current iteration cycle
   let current = 0;
 
@@ -44,9 +48,13 @@ export default function makeThrottle<T extends (...args: any[]) => any>(max: num
             if (queue.length > 0) {
               queue.shift()!();
             }
-          } else {
-            // The `max` has been exceeded - push onto the queue to wait
+          } else if (queueMax < 0 || queue.length < queueMax) {
+            // The `max` has been exceeded and if queue limit hasn't been hit - push onto the queue to wait
             queue.push(handler);
+          } else {
+            // Reject this call due to queue limit
+            reject(new Error("Queue max limit exceeded"));
+            return;
           }
         }
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -40,6 +40,12 @@ export interface ILogtailOptions {
   syncMax: number;
 
   /**
+   * Maximum number of sync requests that can be queued when all concurrent slots are busy.
+   * When the queue limit is reached, new logs will be dropped. (-1 for unlimited queue)
+   */
+  syncQueuedMax: number;
+
+  /**
    * Length of the checked window for logs burst protection in milliseconds (0 to disable)
    */
   burstProtectionMilliseconds: number;


### PR DESCRIPTION
The unlimited queue of requests may lead to memory leaks if the logs can't be sent in time.

The Node.js requests are missing configurable timeouts, which means in rare cases any hanging requests may have lead to `syncMax` being used in full, and new logs just stacking in the queue.