### PR TITLE
fix: add pino 10.0 on peer dependencies

### DIFF
--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "pino": "^7.0.0 || ^8.0.0 || ^9.0.0"
+    "pino": "^7.0.0 || ^8.0.0 || ^9.0.0 || "10.0.0"
   },
   "dependencies": {
     "@logtail/node": "^0.5.6",


### PR DESCRIPTION
## Summary

Pino released a new major version last week. It needs to be supported in the peer dependencies.
- https://github.com/pinojs/pino/releases/tag/v10.0.0