### PR TITLE
Core: add captureStackContext option to disable stack trace capture

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -61,6 +61,9 @@ const defaultOptions: ILogtailOptions = {
 
   // Function to be used to calculate size of logs in bytes (to evaluate batchSizeLimitKiB)
   calculateLogSizeBytes: calculateJsonLogSizeBytes,
+
+  // If true, stack context (file, line, method) will be captured on each log entry
+  captureStackContext: true,
 };
 
 /**

--- a/packages/edge/src/edge.test.ts
+++ b/packages/edge/src/edge.test.ts
@@ -109,6 +109,53 @@ describe("edge tests", () => {
     );
   });
 
+  it("should skip stack context capture when captureStackContext is false", async () => {
+    const message: string = String(Math.random());
+    const edge = new Edge("valid source token", {
+      throwExceptions: true,
+      warnAboutMissingExecutionContext: false,
+      captureStackContext: false,
+    });
+
+    edge.setSync(async (logs) => logs);
+
+    const echoedLog = await edge.log(message);
+    expect(echoedLog.context).toBeUndefined();
+  });
+
+  it("should include stack context by default", async () => {
+    const message: string = String(Math.random());
+    const edge = new Edge("valid source token", {
+      throwExceptions: true,
+      warnAboutMissingExecutionContext: false,
+    });
+
+    edge.setSync(async (logs) => logs);
+
+    const echoedLog = await edge.log(message);
+    expect(typeof echoedLog.context).toBe("object");
+    expect(typeof echoedLog.context.runtime).toBe("object");
+    expect(typeof echoedLog.context.runtime.file).toBe("string");
+    expect(typeof echoedLog.context.runtime.line).toBe("number");
+  });
+
+  it("should include stack context when captureStackContext is explicitly true", async () => {
+    const message: string = String(Math.random());
+    const edge = new Edge("valid source token", {
+      throwExceptions: true,
+      warnAboutMissingExecutionContext: false,
+      captureStackContext: true,
+    });
+
+    edge.setSync(async (logs) => logs);
+
+    const echoedLog = await edge.log(message);
+    expect(typeof echoedLog.context).toBe("object");
+    expect(typeof echoedLog.context.runtime).toBe("object");
+    expect(typeof echoedLog.context.runtime.file).toBe("string");
+    expect(typeof echoedLog.context.runtime.line).toBe("number");
+  });
+
   it("should not warn about missing ExecutionContext if set", async () => {
     const message: string = String(Math.random());
     const edge = new Edge("valid source token", { throwExceptions: true });

--- a/packages/edge/src/edge.ts
+++ b/packages/edge/src/edge.ts
@@ -67,9 +67,11 @@ export class Edge extends Base {
     context: any = {} as TContext,
     ctx?: ExecutionContext,
   ): Promise<ILogtailLog & TContext> {
-    // Process/sync the log, per `Base` logic
-    const stackContext = getStackContext(this);
+    // Only capture stack context if enabled (default: true)
+    const stackContext = this._options.captureStackContext !== false ? getStackContext(this) : {};
     context = { ...stackContext, ...context };
+
+    // Process/sync the log, per `Base` logic
     const log = super.log(message, level, context);
 
     if (ctx) {

--- a/packages/node/src/node.test.ts
+++ b/packages/node/src/node.test.ts
@@ -226,4 +226,47 @@ describe("node tests", () => {
     const result = await node.log("Test message");
     expect(result).toHaveProperty("message", "Test message");
   });
+
+  it("should skip stack context capture when captureStackContext is false", async () => {
+    nock("https://in.logs.betterstack.com").post("/").reply(201);
+
+    const node = new Node("test-token", {
+      captureStackContext: false,
+      throwExceptions: true,
+    });
+
+    const result = await node.log("test message");
+
+    expect(result.message).toBe("test message");
+    expect(result.context).toBeUndefined();
+  });
+
+  it("should include stack context by default", async () => {
+    nock("https://in.logs.betterstack.com").post("/").reply(201);
+
+    const node = new Node("test-token", {
+      throwExceptions: true,
+    });
+
+    const result = await node.log("test message");
+
+    expect(result.message).toBe("test message");
+    expect(result.context).toBeDefined();
+    expect(result.context.runtime).toBeDefined();
+  });
+
+  it("should include stack context when captureStackContext is explicitly true", async () => {
+    nock("https://in.logs.betterstack.com").post("/").reply(201);
+
+    const node = new Node("test-token", {
+      captureStackContext: true,
+      throwExceptions: true,
+    });
+
+    const result = await node.log("test message");
+
+    expect(result.message).toBe("test message");
+    expect(result.context).toBeDefined();
+    expect(result.context.runtime).toBeDefined();
+  });
 });

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -88,8 +88,10 @@ export class Node extends Base {
     context: TContext = {} as TContext,
     stackContextHint?: StackContextHint,
   ) {
-    // Process/sync the log, per `Base` logic
-    context = { ...getStackContext(this, stackContextHint), ...context };
+    // Only capture stack context if enabled (default: true)
+    if (this._options.captureStackContext !== false) {
+      context = { ...getStackContext(this, stackContextHint), ...context } as TContext;
+    }
     const processedLog = await super.log(message, level, context);
 
     // Push the processed log to the stream, for piping

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -95,6 +95,14 @@ export interface ILogtailOptions {
    * Function to be used to calculate size of logs in bytes (to evaluate batchSizeKiB). JSON length by default.
    **/
   calculateLogSizeBytes: (logs: ILogtailLog) => number;
+
+  /**
+   * If false, disables automatic stack context capture (file, line, method) on each log entry.
+   * Stack context capture calls Error.captureStackTrace with stackTraceLimit=Infinity up to 5x per log,
+   * costing ~12μs of synchronous event loop blocking per log entry at scale.
+   * @default true
+   */
+  captureStackContext?: boolean;
 }
 
 export interface ILogtailNodeOptions extends ILogtailOptions {


### PR DESCRIPTION
## Problem

`@logtail/node`'s `Node.log()` and `@logtail/edge`'s `Edge.log()` call `getStackContext()` on every log entry, which:

1. Iterates through 5 Logtail methods (`warn`, `error`, `info`, `debug`, `log`)
2. For each, calls `stackTrace.get(fn)` → `Error.captureStackTrace()` with `stackTraceLimit = Infinity`
3. Walks the **entire V8 call stack** synchronously to extract the calling file, line, method

This costs **~12μs of synchronous event loop blocking per log entry** — and there is currently no way to disable it.

## Benchmark Results

Benchmarked on Node.js v25.6.1 using real `@logtail/node` Logtail instances (with `sendLogsToBetterStack: false`):

| Scenario | Cost per log | ops/s | Speedup |
| --- | --- | --- | --- |
| Default `Logtail.log()` (with `getStackContext`) | **31.3 μs** | 31,939 | — |
| `captureStackContext: false` | **6.1 μs** | 164,837 | **+416%** |

### At scale (simulated 5K-request burst)

| Scenario | Total blocking time | Extrapolated at 2000 logs/sec |
| --- | --- | --- |
| Default | 178.5 ms | ~71.4 ms/s blocked |
| `captureStackContext: false` | 23.5 ms | ~9.4 ms/s blocked |

The remaining ~6μs/log is the baseline cost of the middleware + serialize pipeline — the stack trace capture accounts for **~80% of per-log synchronous cost**.

### Scaling with stack depth

In production NestJS applications with deep middleware chains (interceptors, guards, pipes), the V8 call stack is significantly deeper than in benchmarks, making the real-world cost even higher.

## Solution

Add a `captureStackContext` option to `ILogtailOptions` (default: `true` for backwards compatibility):

```typescript
const logtail = new Logtail(token, {
    captureStackContext: false, // Skip expensive stack trace capture
});
```

When `false`, `Node.log()` and `Edge.log()` skip the `getStackContext()` call entirely, eliminating the synchronous `Error.captureStackTrace` overhead while preserving the full middleware → serialization → batching pipeline.

## Use Case

We discovered this issue while investigating Sentry `EventLoopBlocked` events on our production NestJS API servers (handling 500-2000 req/s). The stack trace capture was the # 1 contributor to synchronous event loop blocking in our logging pipeline.

Our applications using Winston + `@logtail/winston` don't use the `context.runtime` metadata for debugging making this overhead unnecessary.

## Changes

- **`@logtail/types`**: Added `captureStackContext?: boolean` to `ILogtailOptions`
- **`@logtail/core`**: Added default `captureStackContext: true` to `defaultOptions`
- **`@logtail/node`**: `Node.log()` conditionally skips `getStackContext()` when `captureStackContext` is `false`
- **`@logtail/edge`**: `Edge.log()` conditionally skips `getStackContext()` when `captureStackContext` is `false`
- **Tests**: Added test cases for both enabled and disabled stack context capture in both node and edge packages